### PR TITLE
Fix bold rendering for non-ASCII text

### DIFF
--- a/lib/bookshelf_chip_bar.lua
+++ b/lib/bookshelf_chip_bar.lua
@@ -43,6 +43,7 @@ local Font           = require("ui/font")
 local Blitbuffer     = require("ffi/blitbuffer")
 local UIManager      = require("ui/uimanager")
 local Screen         = require("device").screen
+local TextSegments   = require("lib/bookshelf_text_segments")
 
 -- Tab-bar font size scale (percent). 100 = built-in baseline; nudge dialog
 -- accepts 50-300.
@@ -57,51 +58,11 @@ local function _scaled(n)
     return math.floor(n * _fontScale() / 100 + 0.5)
 end
 
--- Classify a label string into runs of "ascii" (bytes < 0x80 -> text) and
--- "icon" (multi-byte UTF-8 sequences -> nerd-font / emoji glyph). Used to
--- render mixed chip labels with bold-only on the text characters; glyphs
--- stay regular so the font's own stroke weight isn't faux-bolded into a
--- blobby mess. ASCII punctuation/spaces classify as "ascii" too -- a space
--- between glyph and word stays inside the bold side of the split so it
--- doesn't visibly thin out (the bold-vs-regular width difference is mostly
--- invisible on a space).
-local function _labelSegments(label)
-    local segments = {}
-    local current  = nil
-    local i = 1
-    while i <= #label do
-        local b = string.byte(label, i)
-        local class, chunk_len
-        if b < 0x80 then
-            class, chunk_len = "ascii", 1
-        elseif b < 0xC0 then
-            -- Continuation byte at start = malformed UTF-8; consume one
-            -- byte and keep going so the iteration doesn't infinite-loop.
-            class, chunk_len = "icon", 1
-        elseif b < 0xE0 then
-            class, chunk_len = "icon", 2
-        elseif b < 0xF0 then
-            class, chunk_len = "icon", 3
-        else
-            class, chunk_len = "icon", 4
-        end
-        local chunk = label:sub(i, i + chunk_len - 1)
-        if current and current.class == class then
-            current.text = current.text .. chunk
-        else
-            current = { class = class, text = chunk }
-            segments[#segments + 1] = current
-        end
-        i = i + chunk_len
-    end
-    return segments
-end
-
 -- Build the cell-content widget for a chip label. Returns either a single
 -- TextWidget (when the label is all-text or all-icon) or a HorizontalGroup
 -- of TextWidgets with mixed bold settings (text bold, icons regular).
 local function _buildLabelContent(label, size, max_w)
-    local segments = _labelSegments((label or ""):upper())
+    local segments = TextSegments.labelSegments((label or ""):upper())
     if #segments == 0 then
         return TextWidget:new{
             text    = "",
@@ -113,7 +74,7 @@ local function _buildLabelContent(label, size, max_w)
         return TextWidget:new{
             text      = segments[1].text,
             face      = Font:getFace("infofont", size),
-            bold      = segments[1].class == "ascii",
+            bold      = segments[1].class == "text",
             fgcolor   = Blitbuffer.COLOR_BLACK,
             max_width = max_w,
         }
@@ -126,7 +87,7 @@ local function _buildLabelContent(label, size, max_w)
         hg[#hg + 1] = TextWidget:new{
             text    = seg.text,
             face    = Font:getFace("infofont", size),
-            bold    = seg.class == "ascii",
+            bold    = seg.class == "text",
             fgcolor = Blitbuffer.COLOR_BLACK,
         }
     end
@@ -138,12 +99,12 @@ end
 -- (no max_width) so the returned size reflects actual glyph metrics.
 local function _measureLabel(label, size)
     local total = 0
-    local segments = _labelSegments((label or ""):upper())
+    local segments = TextSegments.labelSegments((label or ""):upper())
     for _i, seg in ipairs(segments) do
         local tw = TextWidget:new{
             text = seg.text,
             face = Font:getFace("infofont", size),
-            bold = seg.class == "ascii",
+            bold = seg.class == "text",
         }
         total = total + tw:getSize().w
         tw:free()
@@ -559,7 +520,7 @@ function ChipBar:_initChips()
                 height = icon_size,
             }
         else
-            -- Mixed text + icon label: text chars render bold, non-ASCII
+            -- Mixed text + icon label: text chars render bold, icon-like
             -- glyphs render regular. Avoids the faux-bold "blobby" look
             -- on nerd-font / emoji glyphs while keeping "FAVOURITES" the
             -- usual chip-text weight. max_width is honoured for the

--- a/lib/bookshelf_hero_card.lua
+++ b/lib/bookshelf_hero_card.lua
@@ -29,6 +29,7 @@ local SpineWidget     = require("lib/bookshelf_spine_widget")
 local Tokens          = require("lib/bookshelf_tokens")
 local Regions         = require("lib/bookshelf_hero_regions")
 local HeroBar         = require("lib/bookshelf_hero_bar")
+local TextSegments    = require("lib/bookshelf_text_segments")
 
 local HeroCard = InputContainer:extend{
     book                = nil,
@@ -130,48 +131,9 @@ local function regionFace(region)
     return fontFace(region.font_face, region.font_size)
 end
 
--- _labelSegments(text) -- classify a UTF-8 string into runs of "ascii"
--- (bytes < 0x80, plain text) and "icon" (multi-byte sequences, typically
--- nerd-font / emoji glyphs). Mirrors the same helper in
--- bookshelf_chip_bar.lua. Used so a bold region containing icon glyphs
--- can render the text segments bold while leaving the icons at the
--- font's native weight -- faux-bolding nerd-font glyphs renders them as
--- a blobby mess on e-ink.
-local function _labelSegments(label)
-    local segments = {}
-    local current = nil
-    local i = 1
-    while i <= #label do
-        local b = string.byte(label, i)
-        local class, chunk_len
-        if b < 0x80 then
-            class, chunk_len = "ascii", 1
-        elseif b < 0xC0 then
-            -- Continuation byte at start = malformed UTF-8. Consume one
-            -- byte so we don't infinite-loop on bad input.
-            class, chunk_len = "icon", 1
-        elseif b < 0xE0 then
-            class, chunk_len = "icon", 2
-        elseif b < 0xF0 then
-            class, chunk_len = "icon", 3
-        else
-            class, chunk_len = "icon", 4
-        end
-        local chunk = label:sub(i, i + chunk_len - 1)
-        if current and current.class == class then
-            current.text = current.text .. chunk
-        else
-            current = { class = class, text = chunk }
-            segments[#segments + 1] = current
-        end
-        i = i + chunk_len
-    end
-    return segments
-end
-
 -- _buildSegmentedInline(text, face, bold) -- returns a single widget
 -- (TextWidget if homogeneous, HorizontalGroup of TextWidgets if the
--- text mixes ascii + icon segments). When bold is false the function
+-- text mixes text + icon segments). When bold is false the function
 -- short-circuits to a plain TextWidget regardless of content -- the
 -- whole point of segmenting is to keep glyphs out of the bold path,
 -- so non-bold lines have nothing to gain. The returned widget always
@@ -180,7 +142,7 @@ local function _buildSegmentedInline(text, face, bold)
     if not bold or not text:find("[\x80-\xFF]") then
         return TextWidget:new{ text = text, face = face, bold = bold or false }
     end
-    local segments = _labelSegments(text)
+    local segments = TextSegments.labelSegments(text)
     if #segments <= 1 then
         return TextWidget:new{ text = text, face = face, bold = bold }
     end
@@ -189,7 +151,7 @@ local function _buildSegmentedInline(text, face, bold)
         hg[#hg + 1] = TextWidget:new{
             text = seg.text,
             face = face,
-            bold = seg.class == "ascii",
+            bold = seg.class == "text",
         }
     end
     return hg
@@ -210,14 +172,14 @@ local function buildText(text, region, width)
     local face = regionFace(region)
     local is_bold = region.bold or false
     if is_bold and rendered:find("[\x80-\xFF]") and not rendered:find("\n") then
-        local segments = _labelSegments(rendered)
+        local segments = TextSegments.labelSegments(rendered)
         if #segments > 1 then
             local hg = HorizontalGroup:new{ align = "center" }
             for _i, seg in ipairs(segments) do
                 hg[#hg + 1] = TextWidget:new{
                     text    = seg.text,
                     face    = face,
-                    bold    = seg.class == "ascii",
+                    bold    = seg.class == "text",
                     fgcolor = Blitbuffer.COLOR_BLACK,
                 }
             end

--- a/lib/bookshelf_text_segments.lua
+++ b/lib/bookshelf_text_segments.lua
@@ -1,0 +1,89 @@
+-- bookshelf_text_segments.lua
+-- UTF-8 aware label segmentation for mixed text + icon labels.
+--
+-- Ordinary Unicode text (Latin-1, CJK, combining accents, punctuation) stays
+-- in the text class so it can be bolded. Icon-like codepoints (Nerd Font PUA,
+-- dingbats, emoji ranges) are isolated so renderers can leave them regular.
+
+local Segments = {}
+
+local function isContinuation(byte)
+    return byte and byte >= 0x80 and byte < 0xC0
+end
+
+local function decodeAt(str, index)
+    local b1 = string.byte(str, index)
+    if not b1 then return nil end
+    if b1 < 0x80 then
+        return 1, b1, true
+    end
+    if b1 < 0xC0 then
+        return 1, b1, false
+    end
+
+    local b2 = string.byte(str, index + 1)
+    if b1 < 0xE0 then
+        if not isContinuation(b2) then return 1, b1, false end
+        return 2, (b1 - 0xC0) * 0x40 + (b2 - 0x80), true
+    end
+
+    local b3 = string.byte(str, index + 2)
+    if b1 < 0xF0 then
+        if not isContinuation(b2) or not isContinuation(b3) then
+            return 1, b1, false
+        end
+        return 3,
+            (b1 - 0xE0) * 0x1000 + (b2 - 0x80) * 0x40 + (b3 - 0x80),
+            true
+    end
+
+    local b4 = string.byte(str, index + 3)
+    if b1 < 0xF8 then
+        if not isContinuation(b2) or not isContinuation(b3) or not isContinuation(b4) then
+            return 1, b1, false
+        end
+        return 4,
+            (b1 - 0xF0) * 0x40000
+                + (b2 - 0x80) * 0x1000
+                + (b3 - 0x80) * 0x40
+                + (b4 - 0x80),
+            true
+    end
+
+    return 1, b1, false
+end
+
+function Segments.isIconCodepoint(cp)
+    return (cp >= 0xE000 and cp <= 0xF8FF)       -- BMP private use: Nerd Font / MDI
+        or (cp >= 0xF0000 and cp <= 0xFFFFD)     -- supplementary private use A
+        or (cp >= 0x100000 and cp <= 0x10FFFD)   -- supplementary private use B
+        or (cp >= 0x2600 and cp <= 0x27BF)       -- misc symbols / dingbats
+        or (cp >= 0x1F000 and cp <= 0x1FAFF)     -- emoji and pictographs
+end
+
+function Segments.labelSegments(label)
+    label = label or ""
+    local segments = {}
+    local current = nil
+    local i = 1
+
+    while i <= #label do
+        local chunk_len, codepoint, valid = decodeAt(label, i)
+        chunk_len = chunk_len or 1
+        local class = (not valid or Segments.isIconCodepoint(codepoint)) and "icon" or "text"
+        local chunk = label:sub(i, i + chunk_len - 1)
+
+        if current and current.class == class then
+            current.text = current.text .. chunk
+        else
+            current = { class = class, text = chunk }
+            segments[#segments + 1] = current
+        end
+
+        i = i + chunk_len
+    end
+
+    return segments
+end
+
+return Segments

--- a/tests/_test_text_segments.lua
+++ b/tests/_test_text_segments.lua
@@ -1,0 +1,52 @@
+-- tests/_test_text_segments.lua
+-- Pure-Lua unit tests for bookshelf_text_segments.lua.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local Segments = dofile("lib/bookshelf_text_segments.lua")
+
+local pass, fail = 0, 0
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        pass = pass + 1
+    else
+        fail = fail + 1
+        io.stderr:write("FAIL  " .. name .. "\n  " .. tostring(err) .. "\n")
+    end
+end
+
+local function eq(actual, expected, msg)
+    if actual ~= expected then
+        error((msg or "") .. " expected=" .. tostring(expected) .. " got=" .. tostring(actual), 2)
+    end
+end
+
+local function classes(label)
+    local out = {}
+    for _, seg in ipairs(Segments.labelSegments(label)) do
+        out[#out + 1] = seg.class .. ":" .. seg.text
+    end
+    return table.concat(out, "|")
+end
+
+test("latin-1 letters stay text", function()
+    eq(classes("Drömräkning"), "text:Drömräkning")
+    eq(classes("ÅÄÖ åäö"), "text:ÅÄÖ åäö")
+end)
+
+test("non-latin titles stay text", function()
+    eq(classes("進撃の巨人"), "text:進撃の巨人")
+end)
+
+test("private-use nerd font glyphs are icons", function()
+    eq(classes("Manga \239\128\130"), "text:Manga |icon:\239\128\130")
+end)
+
+test("emoji and dingbats are icons", function()
+    eq(classes("Done ✓"), "text:Done |icon:✓")
+    eq(classes("Smile 😀"), "text:Smile |icon:😀")
+end)
+
+print(string.format("\ntext_segments: %d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)


### PR DESCRIPTION
## Summary
- Replace byte-based ASCII/non-ASCII label splitting with UTF-8-aware text/icon segmentation.
- Keep ordinary Unicode text (for example å, ä, ö and CJK titles) in the bold text path.
- Continue isolating Nerd Font/private-use, dingbat, and emoji glyphs so they are not faux-bolded.
- Reuse the shared segmenter in both the chip bar and hero card, with unit coverage.

## Tests
- `luac -p main.lua lib/*.lua tests/_test_*.lua`
- `lua tests/_test_text_segments.lua`

Note: the full plain-Lua test loop on current upstream stops at `_test_cover_progress.lua` because that test requires KOReader's `datastorage` module in this local environment.