### PR TITLE
[codex] Add optional Hardcover enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Below the header you'll find:
 | **Show info** | KOReader's built-in book info dialog. |
 | **Collections (N)…** | Add or remove the book from any collection (Favourites, To Be Read, your own). The number shows current membership. |
 | **Rating** | Set a 1-to-5 star rating, or clear it. |
+| **Hardcover** | Link the book to Hardcover, pick a specific edition, or refresh cached Hardcover metadata. Requires `hardcoverapp.koplugin`. |
 | **Refresh metadata** | Re-read the cover and metadata from the file (useful after editing metadata externally). |
 | **Remove from history** | Drop the book from Recent without changing anything else on disk. |
 | **Reset book data…** | A wider purge with checkboxes for progress, bookmarks, highlights, notes, custom cover, and custom metadata. |
@@ -128,6 +129,19 @@ Collections are named lists of books, and Bookshelf uses KOReader's built-in col
 Open **menu -> Manage collections…** to add new collections, rename or delete existing ones, and **pin** any collection to your chip bar as a dedicated shelf.
 
 To put a book into a collection, long-press its cover and tap **Collections (N)…**. Tick the collections you want, then Save. The pill strip in the book menu's header updates immediately to reflect what's changed.
+
+---
+
+## Hardcover enrichment
+
+If you also use `hardcoverapp.koplugin`, Bookshelf can reuse its book links and cache a small amount of Hardcover metadata for display:
+
+- Missing book descriptions can be filled from Hardcover.
+- Missing local EPUB covers can use cached Hardcover cover images as a Bookshelf-only fallback.
+- Links are managed from a book's long-press menu under **Hardcover**.
+- Network calls only happen from explicit actions such as linking or **Settings -> Hardcover enrichment -> Refresh linked Hardcover metadata**. Normal shelf rendering reads only the local cache.
+
+Bookshelf does not rewrite EPUB files. Hardcover descriptions and cover images are stored in Bookshelf's settings/cache and can be disabled or cleared from **Settings -> Hardcover enrichment**.
 
 ---
 
@@ -499,6 +513,8 @@ Existing v1 settings migrate automatically on first launch -- legacy keys are re
 | `author_format` | `"auto"` / `"first_last"` / `"last_first"` -- author name display. |
 | `bookshelf_ui_font` | Chosen Bookshelf interface font (a resolvable font face). Absent = follow KOReader's UI font. |
 | `cover_cache_mb` | Memory budget (MB) for the scaled-cover cache (default 24). The legacy `cover_cache_size` count key is discarded on first load. |
+| `hardcover_links` / `hardcover_enrichment` | Optional Hardcover link and cached description/cover metadata used by the Hardcover enrichment menu. |
+| `hardcover_fill_descriptions` / `hardcover_fill_covers` | Optional toggles for whether cached Hardcover descriptions/covers fill missing local metadata. Defaults on. |
 | `calibre_metadata` | BETA. Read metadata from `metadata.calibre` if present. |
 | `latest_walk_depth` | How deep the **Latest** source scans your library. |
 | `show_close_msg` | Show the centred "Closing book…" toast when exiting a book. |

--- a/lib/bookshelf_book_repository.lua
+++ b/lib/bookshelf_book_repository.lua
@@ -91,6 +91,16 @@ local function getBookInfoMgr()
     return _bim_cache or nil
 end
 
+local _hardcover_cache
+local function getHardcover()
+    if _hardcover_cache ~= nil then
+        return _hardcover_cache or nil
+    end
+    local ok, mod = pcall(require, "lib/bookshelf_hardcover")
+    _hardcover_cache = (ok and mod) or false
+    return _hardcover_cache or nil
+end
+
 -- Public: true if BookInfoManager is available (CoverBrowser enabled).
 -- main.lua queries this at init to decide whether to take over the home
 -- screen or bail with a "Bookshelf requires CoverBrowser" notification.
@@ -378,7 +388,12 @@ function Repo.buildBookMeta(filepath, opts)
     -- good record we built for this file when BIM doesn't currently
     -- have usable metadata for it.
     if not info.has_meta and _meta_record_cache[filepath] then
-        return _meta_record_cache[filepath]
+        local cached = _meta_record_cache[filepath]
+        local Hardcover = getHardcover()
+        if Hardcover and Hardcover.enrichBook then
+            pcall(Hardcover.enrichBook, cached)
+        end
+        return cached
     end
     -- Calibre is the PRIMARY source for textual metadata when a
     -- metadata.calibre file is available — it already has clean,
@@ -474,6 +489,10 @@ function Repo.buildBookMeta(filepath, opts)
                        or nil,
         page_count  = info.pages,
     }
+    local Hardcover = getHardcover()
+    if Hardcover and Hardcover.enrichBook then
+        pcall(Hardcover.enrichBook, book)
+    end
     -- Cache fresh records whose text metadata is present, with the
     -- cover_bb stripped. ImageWidget marks the cover_bb's
     -- image_disposable=true after first paint -- it's a one-shot

--- a/lib/bookshelf_book_repository.lua
+++ b/lib/bookshelf_book_repository.lua
@@ -39,6 +39,14 @@ local function splitAuthors(s)
     return #t > 0 and t or nil
 end
 
+local function shallowCopyRecord(record)
+    local copy = {}
+    for k, v in pairs(record or {}) do
+        copy[k] = v
+    end
+    return copy
+end
+
 -- Split a genre/tag string (or array of strings) on common EPUB delimiters
 -- (comma, semicolon, pipe, slash) and return a trimmed array, or nil.
 local function splitGenreTags(src)
@@ -388,7 +396,7 @@ function Repo.buildBookMeta(filepath, opts)
     -- good record we built for this file when BIM doesn't currently
     -- have usable metadata for it.
     if not info.has_meta and _meta_record_cache[filepath] then
-        local cached = _meta_record_cache[filepath]
+        local cached = shallowCopyRecord(_meta_record_cache[filepath])
         local Hardcover = getHardcover()
         if Hardcover and Hardcover.enrichBook then
             pcall(Hardcover.enrichBook, cached)
@@ -489,10 +497,6 @@ function Repo.buildBookMeta(filepath, opts)
                        or nil,
         page_count  = info.pages,
     }
-    local Hardcover = getHardcover()
-    if Hardcover and Hardcover.enrichBook then
-        pcall(Hardcover.enrichBook, book)
-    end
     -- Cache fresh records whose text metadata is present, with the
     -- cover_bb stripped. ImageWidget marks the cover_bb's
     -- image_disposable=true after first paint -- it's a one-shot
@@ -513,6 +517,10 @@ function Repo.buildBookMeta(filepath, opts)
             if k ~= "cover_bb" then cached[k] = v end
         end
         _meta_record_cache[filepath] = cached
+    end
+    local Hardcover = getHardcover()
+    if Hardcover and Hardcover.enrichBook then
+        pcall(Hardcover.enrichBook, book)
     end
     return book
 end

--- a/lib/bookshelf_hardcover.lua
+++ b/lib/bookshelf_hardcover.lua
@@ -1,0 +1,852 @@
+-- bookshelf_hardcover.lua
+-- Optional Hardcover enrichment for Bookshelf.
+--
+-- Normal shelf rendering never talks to the network. This module only reads
+-- Bookshelf's local link/enrichment caches there. Network calls happen from
+-- explicit user actions: link a book, refresh one book, or refresh all linked
+-- books.
+
+local BookshelfSettings = require("lib/bookshelf_settings_store")
+
+local Hardcover = {}
+
+local HC_SETTINGS_FILE = "hardcoversync_settings.lua"
+local LINKS_KEY        = "hardcover_links"
+local CACHE_KEY        = "hardcover_enrichment"
+
+local _links
+local _external_links
+local _enrichment_cache
+local _hc_settings
+local _hc_settings_object
+
+local function _settingsPath()
+    local DataStorage = require("datastorage")
+    return DataStorage:getSettingsDir() .. "/" .. HC_SETTINGS_FILE
+end
+
+local function _cacheDir()
+    local DataStorage = require("datastorage")
+    return DataStorage:getSettingsDir() .. "/bookshelf_hardcover"
+end
+
+local function _ensureDir(path)
+    local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+    if not ok_lfs or not lfs or type(lfs.attributes) ~= "function" then return false end
+    if lfs.attributes(path, "mode") == "directory" then return true end
+    if type(lfs.mkdir) == "function" then
+        local ok = pcall(lfs.mkdir, path)
+        return ok and lfs.attributes(path, "mode") == "directory"
+    end
+    return false
+end
+
+local function _openExternalSettings()
+    if _hc_settings then return _hc_settings end
+    local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+    if ok_lfs and lfs and lfs.attributes
+            and lfs.attributes(_settingsPath(), "mode") ~= "file" then
+        return nil
+    end
+    local LuaSettings = require("luasettings")
+    _hc_settings = LuaSettings:open(_settingsPath())
+    return _hc_settings
+end
+
+local function _readLinks()
+    if _links then return _links end
+    local raw = BookshelfSettings.read(LINKS_KEY, {})
+    _links = type(raw) == "table" and raw or {}
+    return _links
+end
+
+local function _saveLinks(links)
+    _links = links or {}
+    BookshelfSettings.save(LINKS_KEY, _links)
+end
+
+local function _readExternalLinks(force)
+    if _external_links and not force then return _external_links end
+    if force then _hc_settings = nil end
+    local ok, settings = pcall(_openExternalSettings)
+    if not ok or not settings then
+        _external_links = {}
+        return _external_links
+    end
+    local ok_books, books = pcall(settings.readSetting, settings, "books")
+    _external_links = (ok_books and type(books) == "table") and books or {}
+    return _external_links
+end
+
+local function _readEnrichmentCache()
+    if _enrichment_cache then return _enrichment_cache end
+    local raw = BookshelfSettings.read(CACHE_KEY, {})
+    _enrichment_cache = type(raw) == "table" and raw or {}
+    return _enrichment_cache
+end
+
+local function _saveEnrichmentCache(cache)
+    _enrichment_cache = cache or {}
+    BookshelfSettings.save(CACHE_KEY, _enrichment_cache)
+end
+
+local function _cacheKey(book_id, edition_id)
+    if not book_id then return nil end
+    if edition_id then
+        return tostring(book_id) .. ":" .. tostring(edition_id)
+    end
+    return tostring(book_id)
+end
+
+local function _shallowCopy(t)
+    local out = {}
+    if type(t) == "table" then
+        for k, v in pairs(t) do out[k] = v end
+    end
+    return out
+end
+
+local function _authorString(book)
+    if not book then return nil end
+    if type(book.authors) == "table" and #book.authors > 0 then
+        return table.concat(book.authors, ", ")
+    end
+    return book.author
+end
+
+local function _filenameTitle(filepath)
+    local name = tostring(filepath or ""):match("([^/]+)$") or ""
+    name = name:gsub("%.[^%.]+$", ""):gsub("_", " ")
+    return name ~= "" and name or nil
+end
+
+local function _shellQuote(s)
+    return "'" .. tostring(s or ""):gsub("'", "'\\''") .. "'"
+end
+
+local function _xmlDecode(s)
+    if not s then return "" end
+    return (s:gsub("&lt;", "<")
+             :gsub("&gt;", ">")
+             :gsub("&quot;", "\"")
+             :gsub("&apos;", "'")
+             :gsub("&amp;", "&")
+             :gsub("^%s+", "")
+             :gsub("%s+$", ""))
+end
+
+local function _attr(attrs, name)
+    if type(attrs) ~= "string" then return nil end
+    local pattern_dq = name .. '%s*=%s*"([^"]+)"'
+    local pattern_sq = name .. "%s*=%s*'([^']+)'"
+    return attrs:match(pattern_dq) or attrs:match(pattern_sq)
+end
+
+local function _normaliseIdentifierToken(attrs, value)
+    value = _xmlDecode(value)
+    if value == "" then return nil end
+    local lower_value = value:lower()
+    if lower_value:match("^hardcover[%w_-]*:") or lower_value:match("^isbn[%w_-]*:") then
+        return value
+    end
+
+    local scheme = _attr(attrs, "opf:scheme") or _attr(attrs, "scheme")
+    if not scheme or scheme == "" then return nil end
+    scheme = scheme:lower():gsub("_", "-")
+    if scheme == "hardcover" or scheme == "hardcover-slug" then
+        return "hardcover:" .. value
+    elseif scheme == "hardcover-id" or scheme == "hardcover-book-id" then
+        return "hardcover-id:" .. value
+    elseif scheme == "hardcover-edition" or scheme == "hardcover-edition-id" then
+        return "hardcover-edition:" .. value
+    elseif scheme == "isbn" or scheme == "isbn10" or scheme == "isbn-10" then
+        return "isbn:" .. value
+    elseif scheme == "isbn13" or scheme == "isbn-13" then
+        return "isbn13:" .. value
+    end
+    return nil
+end
+
+local function _extractIdentifiersFromOpf(opf)
+    if type(opf) ~= "string" or opf == "" then return nil end
+    local tokens, seen = {}, {}
+    local function add(token)
+        if token and token ~= "" and not seen[token] then
+            seen[token] = true
+            tokens[#tokens + 1] = token
+        end
+    end
+    for attrs, value in opf:gmatch("<%s*[%w_%-:]*identifier([^>]*)>(.-)</%s*[%w_%-:]*identifier%s*>") do
+        add(_normaliseIdentifierToken(attrs, value))
+    end
+    for token in opf:gmatch("[Hh][Aa][Rr][Dd][Cc][Oo][Vv][Ee][Rr][%w_-]*%s*:%s*[%w_-]+") do
+        add(token:gsub("%s*:%s*", ":"))
+    end
+    return #tokens > 0 and table.concat(tokens, "\n") or nil
+end
+
+local function _readEmbeddedIdentifiersFromEpub(filepath)
+    if type(filepath) ~= "string" or not filepath:lower():match("%.epub$") then return nil end
+
+    local list_cmd = "unzip -lqq " .. _shellQuote(filepath) .. " '*.opf'"
+    local fh = io.popen(list_cmd, "r")
+    if not fh then return nil end
+    local opf_path
+    for line in fh:lines() do
+        opf_path = line:match("%s+%d+%s+%S+%s+%S+%s+(.+%.opf)$")
+                or line:match("([^%s].-%.opf)$")
+        if opf_path then break end
+    end
+    fh:close()
+    if not opf_path then return nil end
+
+    local read_cmd = "unzip -p " .. _shellQuote(filepath) .. " " .. _shellQuote(opf_path)
+    local opf_fh = io.popen(read_cmd, "r")
+    if not opf_fh then return nil end
+    local chunks, total = {}, 0
+    for chunk in opf_fh:lines() do
+        total = total + #chunk
+        if total > 1024 * 1024 then break end
+        chunks[#chunks + 1] = chunk
+    end
+    opf_fh:close()
+    return _extractIdentifiersFromOpf(table.concat(chunks, "\n"))
+end
+
+local function _loadPickerModules()
+    local ok_api, Api = pcall(require, "hardcover/lib/hardcover_api")
+    if not ok_api or not Api then
+        return nil, "Hardcover API module could not be loaded"
+    end
+    local ok_user, User = pcall(require, "hardcover/lib/user")
+    if not ok_user or not User then
+        return nil, "Hardcover user module could not be loaded"
+    end
+    local ok_dm, DialogManager = pcall(require, "hardcover/lib/ui/dialog_manager")
+    if not ok_dm or not DialogManager then
+        return nil, "Hardcover dialog module could not be loaded"
+    end
+    local ok_book, Book = pcall(require, "hardcover/lib/book")
+    if not ok_book then Book = nil end
+    return {
+        Api = Api,
+        User = User,
+        DialogManager = DialogManager,
+        Book = Book,
+    }
+end
+
+local function _openHardcoverSettingsObject()
+    if _hc_settings_object then return _hc_settings_object end
+    local ok, HardcoverSettings = pcall(require, "hardcover/lib/hardcover_settings")
+    if not ok or not HardcoverSettings or type(HardcoverSettings.new) ~= "function" then
+        return nil, "Hardcover settings module could not be loaded"
+    end
+    local ok_obj, obj = pcall(function()
+        return HardcoverSettings:new(_settingsPath(), { document = { file = nil } })
+    end)
+    if not ok_obj or not obj then
+        return nil, "Could not open Hardcover settings"
+    end
+    _hc_settings_object = obj
+    return _hc_settings_object
+end
+
+local function _openPickerContext()
+    local modules, mod_err = _loadPickerModules()
+    if not modules then return nil, nil, nil, mod_err end
+    local settings, settings_err = _openHardcoverSettingsObject()
+    if not settings then return nil, nil, nil, settings_err end
+    modules.User.settings = settings
+    local ok_user, user_id = pcall(modules.User.getId, modules.User)
+    if not ok_user or not user_id then
+        return nil, nil, nil, "Could not fetch Hardcover user id"
+    end
+    return modules, settings, user_id
+end
+
+local function _linkPayload(hc_book, Book)
+    local delete = {}
+    local function field(name, value)
+        if value == nil then delete[#delete + 1] = name end
+        return value
+    end
+    local book_id = hc_book.book_id or hc_book.id
+    local edition_id = hc_book.edition_id
+    local edition_format = hc_book.edition_format or hc_book.filetype
+    if Book and type(Book.editionFormatName) == "function" then
+        edition_format = Book:editionFormatName(hc_book.edition_format, hc_book.reading_format_id)
+                      or edition_format
+    end
+    return {
+        book_id        = field("book_id", book_id),
+        edition_id     = field("edition_id", edition_id),
+        edition_format = field("edition_format", edition_format),
+        pages          = field("pages", hc_book.pages),
+        title          = field("title", hc_book.title),
+        _delete        = delete,
+    }
+end
+
+local function _applyExternalBookSetting(settings, filepath, config)
+    if not settings then return nil end
+    local books = settings:readSetting("books") or {}
+    books[filepath] = books[filepath] or {}
+    local book_setting = books[filepath]
+    local original = _shallowCopy(book_setting)
+    for k, v in pairs(config or {}) do
+        if k == "_delete" then
+            for _, name in ipairs(v) do
+                book_setting[name] = nil
+            end
+        else
+            book_setting[k] = v
+        end
+    end
+    settings:saveSetting("books", books)
+    settings:flush()
+    return original
+end
+
+local function _notifyLoadedHardcoverSettings(filepath, config, original)
+    local HardcoverSettings = package.loaded["hardcover/lib/hardcover_settings"]
+    if not HardcoverSettings then return end
+    if HardcoverSettings.settings and HardcoverSettings.settings ~= _hc_settings then
+        pcall(_applyExternalBookSetting, HardcoverSettings.settings, filepath, config)
+    end
+    if type(HardcoverSettings.notify) == "function" then
+        pcall(HardcoverSettings.notify, HardcoverSettings, "books", {
+            filename = filepath,
+            config = config,
+        }, original or {})
+    end
+end
+
+local function _mirrorExternalLink(filepath, config)
+    local ok_settings, settings = pcall(_openExternalSettings)
+    if not ok_settings or not settings then return end
+    local original = _applyExternalBookSetting(settings, filepath, config)
+    _notifyLoadedHardcoverSettings(filepath, config, original)
+end
+
+function Hardcover.invalidate()
+    _links = nil
+    _external_links = nil
+    _enrichment_cache = nil
+    _hc_settings = nil
+    _hc_settings_object = nil
+end
+
+function Hardcover.clearEnrichmentCache()
+    _saveEnrichmentCache({})
+    local dir = _cacheDir()
+    local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+    if ok_lfs and lfs and lfs.dir and lfs.attributes
+            and lfs.attributes(dir, "mode") == "directory" then
+        local ok_iter, iter, dir_obj = pcall(lfs.dir, dir)
+        if ok_iter and type(iter) == "function" then
+            for entry in iter, dir_obj do
+                if entry ~= "." and entry ~= ".." then
+                    pcall(os.remove, dir .. "/" .. entry)
+                end
+            end
+        end
+    end
+end
+
+function Hardcover.getLink(filepath)
+    if not filepath then return nil end
+    local link = _readLinks()[filepath]
+    if type(link) == "table" and link.book_id then return link end
+    link = _readExternalLinks(false)[filepath]
+    return type(link) == "table" and link.book_id and link or nil
+end
+
+function Hardcover.linkBook(filepath, hc_book)
+    if not (filepath and hc_book) then
+        return false, "Missing book link data"
+    end
+    local modules = _loadPickerModules()
+    local Book = modules and modules.Book or nil
+    local payload = _linkPayload(hc_book, Book)
+    if not payload.book_id then
+        return false, "Missing Hardcover book id"
+    end
+    local links = _readLinks()
+    links[filepath] = payload
+    _saveLinks(links)
+    pcall(_mirrorExternalLink, filepath, payload)
+    Hardcover.invalidate()
+    return true
+end
+
+function Hardcover.clearLink(filepath)
+    if not filepath then return false, "Missing file path" end
+    local links = _readLinks()
+    links[filepath] = nil
+    _saveLinks(links)
+    pcall(_mirrorExternalLink, filepath, {
+        _delete = { "book_id", "edition_id", "edition_format", "pages", "title" },
+    })
+    Hardcover.invalidate()
+    return true
+end
+
+function Hardcover.linkLabel(filepath)
+    local link = Hardcover.getLink(filepath)
+    if not link or not link.book_id then return nil end
+    local title = link.title or tostring(link.book_id)
+    if link.edition_format and link.edition_format ~= "" then
+        return title .. " · " .. link.edition_format
+    end
+    return title
+end
+
+function Hardcover.getEmbeddedIdentifiers(book)
+    if type(book) ~= "table" then return nil end
+    if type(book.identifiers) == "string" and book.identifiers ~= "" then
+        return book.identifiers
+    end
+    if type(book.identifiers) == "table" then
+        local parts = {}
+        for k, v in pairs(book.identifiers) do
+            if type(v) == "string" or type(v) == "number" then
+                parts[#parts + 1] = tostring(k) .. ":" .. tostring(v)
+            end
+        end
+        if #parts > 0 then
+            book.identifiers = table.concat(parts, "\n")
+            return book.identifiers
+        end
+    end
+    local ok_epub_ids, ids = pcall(_readEmbeddedIdentifiersFromEpub, book.filepath)
+    if not ok_epub_ids then ids = nil end
+    if ids and ids ~= "" then
+        book.identifiers = ids
+        return ids
+    end
+    return nil
+end
+
+local function _parseHardcoverIdentifiers(modules, identifiers)
+    if type(identifiers) ~= "string" or identifiers == "" then return nil end
+    local parsed = {}
+    if modules.Book and type(modules.Book.parseIdentifiers) == "function" then
+        local ok, result = pcall(modules.Book.parseIdentifiers, modules.Book, identifiers)
+        if ok and type(result) == "table" then parsed = result end
+    end
+    local lower = identifiers:lower()
+    for line in lower:gmatch("[^\r\n]+") do
+        local key, value = line:match("^%s*([^:%s]+)%s*:%s*([^%s]+)")
+        if key and value then
+            key = key:gsub("_", "-")
+            local digits = value:gsub("[^%dx]", "")
+            if key == "hardcover" or key == "hardcover-slug" then
+                parsed.book_slug = parsed.book_slug or value
+            elseif key == "hardcover-edition" or key == "hardcover-edition-id"
+                    or key == "hardcoveredition" or key == "hardcovereditionid" then
+                parsed.edition_id = parsed.edition_id or digits
+            elseif key == "isbn" or key == "isbn13" or key == "isbn-13"
+                    or key == "isbn10" or key == "isbn-10" then
+                if #digits == 13 then
+                    parsed.isbn_13 = parsed.isbn_13 or digits
+                elseif #digits == 10 then
+                    parsed.isbn_10 = parsed.isbn_10 or digits
+                end
+            end
+        end
+    end
+    parsed.book_id = parsed.book_id
+        or lower:match("hardcover%-book%-id%s*:%s*(%d+)")
+        or lower:match("hardcover%-id%s*:%s*(%d+)")
+        or lower:match("hardcoverbookid%s*:%s*(%d+)")
+        or lower:match("hardcoverid%s*:%s*(%d+)")
+    return next(parsed) and parsed or nil
+end
+
+local function _lookupBookByIdentifiers(modules, parsed, user_id)
+    if not parsed or not next(parsed) then return nil end
+    local ok_lookup, book = pcall(function()
+        return modules.Api:findBookByIdentifiers(parsed, user_id)
+    end)
+    return ok_lookup and book or nil
+end
+
+local function _findBookByIdentifiers(modules, identifiers, user_id)
+    local parsed = _parseHardcoverIdentifiers(modules, identifiers)
+    if not parsed then return nil end
+
+    if parsed.edition_id then
+        local book = _lookupBookByIdentifiers(modules, parsed, user_id)
+        if book then return book end
+    end
+
+    -- ISBN usually resolves to the exact edition, while a Hardcover slug/id
+    -- often resolves to the parent work. Prefer ISBN unless an explicit
+    -- Hardcover edition id was embedded.
+    if parsed.isbn_13 or parsed.isbn_10 then
+        local isbn_only = {
+            isbn_13 = parsed.isbn_13,
+            isbn_10 = parsed.isbn_10,
+        }
+        local book = _lookupBookByIdentifiers(modules, isbn_only, user_id)
+        if book then return book end
+    end
+
+    local book = _lookupBookByIdentifiers(modules, parsed, user_id)
+    if book then return book end
+
+    local numeric_id = parsed.book_id
+    if not numeric_id and parsed.book_slug and tostring(parsed.book_slug):match("^%d+$") then
+        numeric_id = parsed.book_slug
+    end
+    numeric_id = tonumber(numeric_id)
+    if numeric_id and type(modules.Api.hydrateBooks) == "function" then
+        local ok_hydrate, books = pcall(function()
+            return modules.Api:hydrateBooks({ numeric_id }, user_id)
+        end)
+        if ok_hydrate and type(books) == "table" and books[1] then
+            return books[1]
+        end
+    end
+    return nil
+end
+
+local function _newDialogManager(modules, settings)
+    modules.User.settings = settings
+    return modules.DialogManager:new{ settings = settings }
+end
+
+function Hardcover.linkFromEmbeddedIdentifiers(book, opts)
+    opts = opts or {}
+    if not (book and book.filepath) then return false, "Missing local book" end
+    local identifiers = Hardcover.getEmbeddedIdentifiers(book)
+    if not identifiers then return false, "No embedded Hardcover identifier found" end
+
+    local modules, _settings, user_id, ctx_err = _openPickerContext()
+    if not modules then return false, ctx_err end
+    local hc_book = _findBookByIdentifiers(modules, identifiers, user_id)
+    if not hc_book then return false, "No Hardcover match found for embedded identifier" end
+
+    local ok, link_err = Hardcover.linkBook(book.filepath, hc_book)
+    if not ok then return false, link_err end
+    if opts.on_linked then opts.on_linked(hc_book) end
+    return true, hc_book
+end
+
+function Hardcover.showBookPicker(book, opts)
+    opts = opts or {}
+    if not (book and book.filepath) then return false, "Missing local book" end
+    local modules, settings, user_id, ctx_err = _openPickerContext()
+    if not modules then return false, ctx_err end
+    local title = book.title or _filenameTitle(book.filepath)
+    local author = _authorString(book)
+    local books, err
+    local embedded = _findBookByIdentifiers(modules, Hardcover.getEmbeddedIdentifiers(book), user_id)
+    if embedded then
+        books = { embedded }
+    else
+        books, err = modules.Api:findBooks(title, author, user_id)
+    end
+    if not books then return false, err or "No response from Hardcover" end
+
+    local manager = _newDialogManager(modules, settings)
+    manager:buildSearchDialog(
+        "Select Hardcover book",
+        books,
+        { book_id = (Hardcover.getLink(book.filepath) or {}).book_id },
+        function(selected)
+            local ok, link_err = Hardcover.linkBook(book.filepath, selected)
+            if not ok then
+                if opts.on_error then opts.on_error(link_err) end
+                return
+            end
+            local ok_refresh, refresh_err = Hardcover.refreshBook(book, { force = true })
+            if opts.on_book_selected then
+                opts.on_book_selected(selected, ok_refresh, refresh_err)
+            end
+        end,
+        function(search)
+            manager:updateSearchResults(search)
+            return true
+        end,
+        title
+    )
+    return true
+end
+
+function Hardcover.showEditionPicker(book, book_id, opts)
+    opts = opts or {}
+    if not (book and book.filepath and book_id) then
+        return false, "Missing Hardcover book id"
+    end
+    local modules, settings, user_id, ctx_err = _openPickerContext()
+    if not modules then return false, ctx_err end
+    local editions = modules.Api:findEditions(book_id, user_id)
+    if not editions then return false, "Could not fetch Hardcover editions" end
+
+    local link = Hardcover.getLink(book.filepath) or {}
+    local manager = _newDialogManager(modules, settings)
+    manager:buildSearchDialog(
+        "Select Hardcover edition",
+        editions,
+        { edition_id = link.edition_id },
+        function(selected)
+            local ok, link_err = Hardcover.linkBook(book.filepath, selected)
+            if not ok then
+                if opts.on_error then opts.on_error(link_err) end
+                return
+            end
+            local ok_refresh, refresh_err = Hardcover.refreshBook(book, { force = true })
+            if opts.on_edition_selected then
+                opts.on_edition_selected(selected, ok_refresh, refresh_err)
+            end
+        end
+    )
+    return true
+end
+
+local function _loadApi()
+    local ok, Api = pcall(require, "hardcover/lib/hardcover_api")
+    if not ok or not Api or type(Api.query) ~= "function" then
+        return nil, "Hardcover plugin/API module could not be loaded"
+    end
+    return Api
+end
+
+local function _errString(err)
+    if type(err) == "table" then
+        if type(err.errors) == "table" and err.errors[1] then
+            local first = err.errors[1]
+            if type(first) == "table" and first.message then
+                return tostring(first.message)
+            end
+            return tostring(first)
+        end
+        if err.error then return tostring(err.error) end
+    end
+    return tostring(err)
+end
+
+local function _imageUrl(row)
+    if type(row) ~= "table" then return nil end
+    if type(row.cached_image) == "string" and row.cached_image ~= "" then
+        return row.cached_image
+    end
+    if type(row.image) == "table" and type(row.image.url) == "string" then
+        return row.image.url
+    end
+    return nil
+end
+
+local function _downloadImage(url, key, force)
+    if type(url) ~= "string" or url == "" or not key then return nil end
+    local dir = _cacheDir()
+    if not _ensureDir(dir) then return nil end
+    local ext = url:match("%.([jJ][pP][eE]?[gG])[%?%#]?") and "jpg"
+            or url:match("%.([pP][nN][gG])[%?%#]?") and "png"
+            or "jpg"
+    local safe_key = tostring(key):gsub("[^%w_.-]", "_")
+    local path = dir .. "/" .. safe_key .. "." .. ext
+
+    local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+    if ok_lfs and lfs and lfs.attributes
+            and lfs.attributes(path, "mode") == "file"
+            and not force then
+        return path
+    end
+
+    local ok_require, http, ltn12, socket, socketutil = pcall(function()
+        return require("socket/http"),
+               require("ltn12"),
+               require("socket"),
+               require("socketutil")
+    end)
+    if not ok_require then return nil end
+
+    local tmp = path .. ".tmp"
+    local file = io.open(tmp, "wb")
+    if not file then return nil end
+    local ok_req, code = pcall(function()
+        socketutil:set_timeout(socketutil.LARGE_BLOCK_TIMEOUT, socketutil.LARGE_TOTAL_TIMEOUT)
+        local c = socket.skip(1, http.request({
+            url = url,
+            method = "GET",
+            headers = { ["User-Agent"] = "KOReader-Bookshelf" },
+            sink = ltn12.sink.file(file),
+            redirect = true,
+        }))
+        socketutil:reset_timeout()
+        return c
+    end)
+    pcall(function() socketutil:reset_timeout() end)
+    if not ok_req or code ~= 200 then
+        pcall(os.remove, tmp)
+        return nil
+    end
+    pcall(os.remove, path)
+    local ok_rename = os.rename(tmp, path)
+    if not ok_rename then
+        pcall(os.remove, tmp)
+        return nil
+    end
+    return path
+end
+
+local function _fetchBookEnrichment(book_id, edition_id, opts)
+    opts = opts or {}
+    local Api, api_err = _loadApi()
+    if not Api then return false, api_err end
+    book_id = tonumber(book_id) or book_id
+    edition_id = tonumber(edition_id) or edition_id
+    if not book_id then return false, "Missing Hardcover book id" end
+
+    local data, err
+    if edition_id then
+        local query = [[
+            query ($bookId: Int!, $editionId: Int!) {
+              book: books_by_pk(id: $bookId) {
+                id
+                title
+                description
+                cached_image
+              }
+              edition: editions_by_pk(id: $editionId) {
+                id
+                title
+                cached_image
+              }
+            }
+        ]]
+        local ok_query
+        ok_query, data, err = pcall(Api.query, Api, query, {
+            bookId = book_id,
+            editionId = edition_id,
+        })
+        if not ok_query then
+            return false, "Hardcover enrichment failed: " .. _errString(data)
+        end
+    else
+        local query = [[
+            query ($bookId: Int!) {
+              book: books_by_pk(id: $bookId) {
+                id
+                title
+                description
+                cached_image
+              }
+            }
+        ]]
+        local ok_query
+        ok_query, data, err = pcall(Api.query, Api, query, { bookId = book_id })
+        if not ok_query then
+            return false, "Hardcover enrichment failed: " .. _errString(data)
+        end
+    end
+    if not data or type(data.book) ~= "table" then
+        return false, err and ("Hardcover enrichment failed: " .. _errString(err))
+            or "No response from Hardcover"
+    end
+
+    local edition = type(data.edition) == "table" and data.edition or nil
+    local image_url = _imageUrl(edition) or _imageUrl(data.book)
+    local key = _cacheKey(book_id, edition_id)
+    local cover_path = image_url and _downloadImage(image_url, key, opts.force) or nil
+    return true, {
+        book_id = data.book.id or book_id,
+        edition_id = edition and (edition.id or edition_id) or edition_id,
+        title = (edition and edition.title) or data.book.title,
+        description = data.book.description,
+        cover_url = image_url,
+        cover_path = cover_path,
+        fetched_at = os.time(),
+    }
+end
+
+function Hardcover.getCachedEnrichment(book_id, edition_id)
+    local cache = _readEnrichmentCache()
+    local key = _cacheKey(book_id, edition_id)
+    local entry = key and cache[key] or nil
+    if type(entry) == "table" then return entry end
+    if edition_id then
+        entry = cache[_cacheKey(book_id)]
+        if type(entry) == "table" then return entry end
+    end
+    return nil
+end
+
+function Hardcover.refreshBook(book, opts)
+    opts = opts or {}
+    if not (book and book.filepath) then return false, "Missing local book" end
+    local link = Hardcover.getLink(book.filepath)
+    if not link or not link.book_id then return false, "Book is not linked to Hardcover" end
+    local ok, payload = _fetchBookEnrichment(link.book_id, link.edition_id, opts)
+    if not ok then return false, payload end
+    local cache = _readEnrichmentCache()
+    cache[_cacheKey(link.book_id, link.edition_id)] = payload
+    _saveEnrichmentCache(cache)
+    if opts.on_refreshed then opts.on_refreshed(payload) end
+    return true, payload
+end
+
+function Hardcover.refreshAllLinked()
+    local linked, updated, failed = 0, 0, 0
+    local errors = {}
+    local seen = {}
+    local function process(_filepath, link)
+        if type(link) ~= "table" or not link.book_id then return end
+        local key = _cacheKey(link.book_id, link.edition_id)
+        if seen[key] then return end
+        seen[key] = true
+        linked = linked + 1
+        local ok, payload = _fetchBookEnrichment(link.book_id, link.edition_id, { force = true })
+        if ok then
+            local cache = _readEnrichmentCache()
+            cache[key] = payload
+            _saveEnrichmentCache(cache)
+            updated = updated + 1
+        else
+            failed = failed + 1
+            errors[#errors + 1] = tostring(payload)
+        end
+    end
+    for fp, link in pairs(_readExternalLinks(true)) do process(fp, link) end
+    for fp, link in pairs(_readLinks()) do process(fp, link) end
+    return true, {
+        linked = linked,
+        updated = updated,
+        failed = failed,
+        errors = errors,
+    }
+end
+
+function Hardcover.enrichBook(book)
+    if not book or not book.filepath then return book end
+    local link = Hardcover.getLink(book.filepath)
+    if not link then return book end
+
+    book.hardcover_book_id = tonumber(link.book_id) or link.book_id
+    book.hardcover_edition_id = tonumber(link.edition_id) or link.edition_id
+    book.hardcover_title = link.title
+
+    local enrichment = Hardcover.getCachedEnrichment(link.book_id, link.edition_id)
+    if type(enrichment) ~= "table" then return book end
+
+    if BookshelfSettings.nilOrTrue("hardcover_fill_descriptions")
+            and (not book.description or book.description == "")
+            and type(enrichment.description) == "string"
+            and enrichment.description ~= "" then
+        book.description = enrichment.description
+        book.hardcover_description = true
+    end
+    if BookshelfSettings.nilOrTrue("hardcover_fill_covers")
+            and not book.has_cover
+            and type(enrichment.cover_path) == "string"
+            and enrichment.cover_path ~= "" then
+        book.cover_image_path = enrichment.cover_path
+        book.hardcover_cover = true
+    end
+    return book
+end
+
+return Hardcover

--- a/lib/bookshelf_hardcover.lua
+++ b/lib/bookshelf_hardcover.lua
@@ -236,6 +236,28 @@ local function _loadPickerModules()
     }
 end
 
+local function _runWhenOnline(fn, on_error)
+    local ok_network, NetworkMgr = pcall(require, "ui/network/manager")
+    if ok_network and NetworkMgr and type(NetworkMgr.runWhenOnline) == "function" then
+        local ok_run = pcall(function()
+            NetworkMgr:runWhenOnline(function()
+                local ok, err = pcall(fn)
+                if not ok and on_error then on_error(tostring(err)) end
+            end)
+        end)
+        if ok_run then
+            return true
+        end
+    end
+
+    local ok, err = pcall(fn)
+    if not ok then
+        if on_error then on_error(tostring(err)) end
+        return false, err
+    end
+    return true
+end
+
 local function _openHardcoverSettingsObject()
     if _hc_settings_object then return _hc_settings_object end
     local ok, HardcoverSettings = pcall(require, "hardcover/lib/hardcover_settings")
@@ -561,10 +583,11 @@ function Hardcover.showBookPicker(book, opts)
                 if opts.on_error then opts.on_error(link_err) end
                 return
             end
-            local ok_refresh, refresh_err = Hardcover.refreshBook(book, { force = true })
-            if opts.on_book_selected then
-                opts.on_book_selected(selected, ok_refresh, refresh_err)
-            end
+            Hardcover.refreshBookOnline(book, { force = true }, function(ok_refresh, refresh_err)
+                if opts.on_book_selected then
+                    opts.on_book_selected(selected, ok_refresh, refresh_err)
+                end
+            end)
         end,
         function(search)
             manager:updateSearchResults(search)
@@ -597,10 +620,11 @@ function Hardcover.showEditionPicker(book, book_id, opts)
                 if opts.on_error then opts.on_error(link_err) end
                 return
             end
-            local ok_refresh, refresh_err = Hardcover.refreshBook(book, { force = true })
-            if opts.on_edition_selected then
-                opts.on_edition_selected(selected, ok_refresh, refresh_err)
-            end
+            Hardcover.refreshBookOnline(book, { force = true }, function(ok_refresh, refresh_err)
+                if opts.on_edition_selected then
+                    opts.on_edition_selected(selected, ok_refresh, refresh_err)
+                end
+            end)
         end
     )
     return true
@@ -641,6 +665,13 @@ end
 
 local function _downloadImage(url, key, force)
     if type(url) ~= "string" or url == "" or not key then return nil end
+    local ok_network, NetworkMgr = pcall(require, "ui/network/manager")
+    if ok_network and NetworkMgr and type(NetworkMgr.isOnline) == "function" then
+        local ok_online, is_online = pcall(NetworkMgr.isOnline, NetworkMgr)
+        if ok_online and not is_online then
+            return nil
+        end
+    end
     local dir = _cacheDir()
     if not _ensureDir(dir) then return nil end
     local ext = url:match("%.([jJ][pP][eE]?[gG])[%?%#]?") and "jpg"
@@ -789,6 +820,16 @@ function Hardcover.refreshBook(book, opts)
     return true, payload
 end
 
+function Hardcover.refreshBookOnline(book, opts, callback)
+    opts = opts or {}
+    return _runWhenOnline(function()
+        local ok, payload = Hardcover.refreshBook(book, opts)
+        if callback then callback(ok, payload) end
+    end, function(err)
+        if callback then callback(false, err) end
+    end)
+end
+
 function Hardcover.refreshAllLinked()
     local linked, updated, failed = 0, 0, 0
     local errors = {}
@@ -818,6 +859,15 @@ function Hardcover.refreshAllLinked()
         failed = failed,
         errors = errors,
     }
+end
+
+function Hardcover.refreshAllLinkedOnline(callback)
+    return _runWhenOnline(function()
+        local ok, stats = Hardcover.refreshAllLinked()
+        if callback then callback(ok, stats) end
+    end, function(err)
+        if callback then callback(false, err) end
+    end)
 end
 
 function Hardcover.enrichBook(book)

--- a/lib/bookshelf_settings.lua
+++ b/lib/bookshelf_settings.lua
@@ -1202,15 +1202,16 @@ function Settings:_hardcoverSubItems()
                         notify(_("Hardcover integration could not be loaded"))
                         return
                     end
-                    local ok, stats = Hardcover.refreshAllLinked()
-                    if not ok then
-                        notify(tostring(stats or _("Hardcover refresh failed")), 5)
-                        return
-                    end
-                    markDirty("hardcover-refresh")
-                    notify(T(_("Hardcover metadata refreshed: %1 updated, %2 failed"),
-                             tostring(stats.updated or 0),
-                             tostring(stats.failed or 0)), 4)
+                    Hardcover.refreshAllLinkedOnline(function(ok, stats)
+                        if not ok then
+                            notify(tostring(stats or _("Hardcover refresh failed")), 5)
+                            return
+                        end
+                        markDirty("hardcover-refresh")
+                        notify(T(_("Hardcover metadata refreshed: %1 updated, %2 failed"),
+                                 tostring(stats.updated or 0),
+                                 tostring(stats.failed or 0)), 4)
+                    end)
                 end)
             end,
         },

--- a/lib/bookshelf_settings.lua
+++ b/lib/bookshelf_settings.lua
@@ -1127,9 +1127,108 @@ function Settings:_settingsSubItems()
             end,
         },
         {
+            text                = _("Hardcover enrichment"),
+            sub_item_table_func = function()
+                return self:_hardcoverSubItems()
+            end,
+        },
+        {
             text                = _("Advanced settings"),
             sub_item_table_func = function()
                 return self:_advancedSubItems()
+            end,
+        },
+    }
+end
+
+function Settings:_hardcoverSubItems()
+    local function markDirty(reason)
+        pcall(function()
+            require("lib/bookshelf_book_repository").invalidateBookCache(reason or "hardcover")
+        end)
+        pcall(function()
+            require("lib/bookshelf_image_source").invalidateCache()
+        end)
+        if self._bw and self._bw._rebuild then
+            self._bw:_rebuild()
+            UIManager:setDirty(self._bw, "ui")
+        end
+    end
+
+    local function notify(text, timeout)
+        UIManager:show(Notification:new{
+            text    = text,
+            timeout = timeout or 3,
+        })
+    end
+
+    return {
+        {
+            text = _("Fill missing descriptions from Hardcover"),
+            help_text = _("When a book is linked to Hardcover and Bookshelf has cached a description for it, use that text only if the EPUB has no description of its own."),
+            checked_func = function()
+                return BookshelfSettings.nilOrTrue("hardcover_fill_descriptions")
+            end,
+            keep_menu_open = true,
+            callback = function()
+                local enabled = BookshelfSettings.nilOrTrue("hardcover_fill_descriptions")
+                BookshelfSettings.save("hardcover_fill_descriptions", not enabled)
+                markDirty("hardcover-description-toggle")
+            end,
+        },
+        {
+            text = _("Use Hardcover covers when missing"),
+            help_text = _("When a linked book has no embedded EPUB cover, use the cached Hardcover cover image as a Bookshelf-only fallback. EPUB files are not modified."),
+            checked_func = function()
+                return BookshelfSettings.nilOrTrue("hardcover_fill_covers")
+            end,
+            keep_menu_open = true,
+            callback = function()
+                local enabled = BookshelfSettings.nilOrTrue("hardcover_fill_covers")
+                BookshelfSettings.save("hardcover_fill_covers", not enabled)
+                markDirty("hardcover-cover-toggle")
+            end,
+        },
+        {
+            text = _("Refresh linked Hardcover metadata"),
+            help_text = _("Fetch descriptions and cover images for books already linked to Hardcover. Rendering never contacts Hardcover; this explicit refresh updates Bookshelf's local cache."),
+            callback = function(touchmenu_instance)
+                if touchmenu_instance then
+                    UIManager:close(touchmenu_instance)
+                end
+                UIManager:nextTick(function()
+                    local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+                    if not ok_hc or not Hardcover then
+                        notify(_("Hardcover integration could not be loaded"))
+                        return
+                    end
+                    local ok, stats = Hardcover.refreshAllLinked()
+                    if not ok then
+                        notify(tostring(stats or _("Hardcover refresh failed")), 5)
+                        return
+                    end
+                    markDirty("hardcover-refresh")
+                    notify(T(_("Hardcover metadata refreshed: %1 updated, %2 failed"),
+                             tostring(stats.updated or 0),
+                             tostring(stats.failed or 0)), 4)
+                end)
+            end,
+        },
+        {
+            text = _("Clear Hardcover cache"),
+            help_text = _("Remove Bookshelf's cached Hardcover descriptions and downloaded cover images. Existing book links are kept."),
+            callback = function(touchmenu_instance)
+                if touchmenu_instance then
+                    UIManager:close(touchmenu_instance)
+                end
+                UIManager:nextTick(function()
+                    local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+                    if ok_hc and Hardcover and Hardcover.clearEnrichmentCache then
+                        Hardcover.clearEnrichmentCache()
+                    end
+                    markDirty("hardcover-clear-cache")
+                    notify(_("Hardcover cache cleared"))
+                end)
             end,
         },
     }

--- a/lib/bookshelf_spine_widget.lua
+++ b/lib/bookshelf_spine_widget.lua
@@ -467,9 +467,13 @@ function SpineWidget:init()
     --     override, or book.cover_bb populated by buildBookMeta with the
     --     default want_cover=true) OR we have a filepath to drive the
     --     lazy path (ScaledCoverCache hit or Repo.getCoverBB on miss).
+    --   * OR book.cover_image_path is a cached external enrichment cover
+    --     (currently Hardcover) for a book whose EPUB has no embedded cover.
     local effective_bb = self.cover_bb or (self.book and self.book.cover_bb)
     local can_lazy     = self.book and self.book.filepath
-    if self.book and self.book.has_cover and (effective_bb or can_lazy) then
+    local external_cover = self.book and self.book.cover_image_path
+    if self.book
+            and ((self.book.has_cover and (effective_bb or can_lazy)) or external_cover) then
         self[1] = self:_renderCover(effective_bb)
     else
         self[1] = self:_renderFallback()
@@ -961,6 +965,23 @@ function SpineWidget:_renderCover(bb)
     local img_w = card_w - 2 * border
     local img_h = card_h - 2 * border
     local fp = self.book and self.book.filepath
+    local external_cover = self.book
+        and not self.book.has_cover
+        and self.book.cover_image_path
+
+    if external_cover then
+        local ok_img, ImageSource = pcall(require, "lib/bookshelf_image_source")
+        local external_bb = ok_img and ImageSource.loadImage(external_cover, img_w, img_h) or nil
+        if external_bb then
+            return self:_wrapCoverInCard(
+                ImageWidget:new{
+                    image            = external_bb,
+                    image_disposable = false,
+                    scale_factor     = 1,
+                },
+                card_w, card_h, border)
+        end
+    end
 
     -- Cache-first. ScaledCoverCache is keyed by filepath only (one bb
     -- per book at canonical/max-seen dims). On hit, if the cached bb

--- a/lib/bookshelf_widget.lua
+++ b/lib/bookshelf_widget.lua
@@ -7190,13 +7190,14 @@ function BookshelfWidget:_openHardcoverMenu(book)
     end
 
     local function refreshLinkedMetadata(success_text)
-        local ok, err = Hardcover.refreshBook(book, { force = true })
-        refreshAfterAction("hardcover-refresh-one")
-        if ok then
-            bw:_hardcoverToast(success_text or _("Hardcover metadata refreshed"))
-        else
-            bw:_hardcoverToast(tostring(err or _("Hardcover refresh failed")), 5)
-        end
+        Hardcover.refreshBookOnline(book, { force = true }, function(ok, err)
+            refreshAfterAction("hardcover-refresh-one")
+            if ok then
+                bw:_hardcoverToast(success_text or _("Hardcover metadata refreshed"))
+            else
+                bw:_hardcoverToast(tostring(err or _("Hardcover refresh failed")), 5)
+            end
+        end)
     end
 
     local embedded_button = {

--- a/lib/bookshelf_widget.lua
+++ b/lib/bookshelf_widget.lua
@@ -28,6 +28,7 @@ local ChipBar   = require("lib/bookshelf_chip_bar")
 local ShelfRow    = require("lib/bookshelf_shelf_row")
 local SpineWidget = require("lib/bookshelf_spine_widget")
 local logger      = require("logger")
+local T           = require("ffi/util").template
 
 -- Wall-clock timer for perf instrumentation. LuaSocket's gettime() gives
 -- fractional seconds including I/O waits; os.clock() is CPU-only (fallback).
@@ -7149,6 +7150,156 @@ function BookshelfWidget:_showFullDescription(book)
     UIManager:show(viewer)
 end
 
+function BookshelfWidget:_refreshHardcoverEnrichmentView(reason)
+    Repo.invalidateBookCache(reason or "hardcover")
+    pcall(function() require("lib/bookshelf_image_source").invalidateCache() end)
+    if self._rebuild then
+        self:_rebuild()
+        UIManager:setDirty(self, "ui")
+    end
+end
+
+function BookshelfWidget:_hardcoverToast(text, timeout)
+    UIManager:show(require("ui/widget/notification"):new{
+        text    = text,
+        timeout = timeout or 3,
+    })
+end
+
+function BookshelfWidget:_openHardcoverMenu(book)
+    if not (book and book.filepath) then return end
+    local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+    if not ok_hc or not Hardcover then
+        self:_hardcoverToast(_("Hardcover integration could not be loaded"))
+        return
+    end
+
+    local bw = self
+    local link = Hardcover.getLink(book.filepath)
+    local dialog
+
+    local function closeThen(fn)
+        return function()
+            UIManager:close(dialog)
+            if fn then UIManager:nextTick(fn) end
+        end
+    end
+
+    local function refreshAfterAction(reason)
+        bw:_refreshHardcoverEnrichmentView(reason or "hardcover-link")
+    end
+
+    local function refreshLinkedMetadata(success_text)
+        local ok, err = Hardcover.refreshBook(book, { force = true })
+        refreshAfterAction("hardcover-refresh-one")
+        if ok then
+            bw:_hardcoverToast(success_text or _("Hardcover metadata refreshed"))
+        else
+            bw:_hardcoverToast(tostring(err or _("Hardcover refresh failed")), 5)
+        end
+    end
+
+    local embedded_button = {
+        text = _("Link embedded IDs"),
+        callback = closeThen(function()
+            local ok, result = Hardcover.linkFromEmbeddedIdentifiers(book)
+            if not ok then
+                bw:_hardcoverToast(tostring(result or _("No embedded Hardcover identifier found")), 5)
+                return
+            end
+            refreshLinkedMetadata(_("Hardcover book linked"))
+        end),
+    }
+
+    local select_book_button = {
+        text = _("Select book") .. "\xE2\x80\xA6",
+        callback = closeThen(function()
+            local ok, err = Hardcover.showBookPicker(book, {
+                on_error = function(msg)
+                    bw:_hardcoverToast(tostring(msg or _("Hardcover link failed")), 5)
+                end,
+                on_book_selected = function(_selected, ok_refresh, refresh_err)
+                    refreshAfterAction("hardcover-select-book")
+                    if ok_refresh == false then
+                        bw:_hardcoverToast(T(_("Book linked, but metadata refresh failed: %1"),
+                                             tostring(refresh_err)), 5)
+                    else
+                        bw:_hardcoverToast(_("Hardcover book linked"))
+                    end
+                end,
+            })
+            if not ok then
+                bw:_hardcoverToast(tostring(err or _("Hardcover search failed")), 5)
+            end
+        end),
+    }
+
+    local select_edition_button = {
+        text = _("Select edition") .. "\xE2\x80\xA6",
+        enabled = link and link.book_id and true or false,
+        callback = closeThen(function()
+            local current = Hardcover.getLink(book.filepath)
+            if not current or not current.book_id then
+                bw:_hardcoverToast(_("Link a Hardcover book first"))
+                return
+            end
+            local ok, err = Hardcover.showEditionPicker(book, current.book_id, {
+                on_error = function(msg)
+                    bw:_hardcoverToast(tostring(msg or _("Hardcover link failed")), 5)
+                end,
+                on_edition_selected = function(_selected, ok_refresh, refresh_err)
+                    refreshAfterAction("hardcover-select-edition")
+                    if ok_refresh == false then
+                        bw:_hardcoverToast(T(_("Edition linked, but metadata refresh failed: %1"),
+                                             tostring(refresh_err)), 5)
+                    else
+                        bw:_hardcoverToast(_("Hardcover edition linked"))
+                    end
+                end,
+            })
+            if not ok then
+                bw:_hardcoverToast(tostring(err or _("Hardcover edition search failed")), 5)
+            end
+        end),
+    }
+
+    local refresh_button = {
+        text = _("Refresh metadata"),
+        enabled = link and link.book_id and true or false,
+        callback = closeThen(function()
+            refreshLinkedMetadata()
+        end),
+    }
+
+    local clear_button = {
+        text = _("Clear link"),
+        enabled = link and true or false,
+        callback = closeThen(function()
+            local ok, err = Hardcover.clearLink(book.filepath)
+            refreshAfterAction("hardcover-clear-link")
+            if ok then
+                bw:_hardcoverToast(_("Hardcover link cleared"))
+            else
+                bw:_hardcoverToast(tostring(err or _("Could not clear Hardcover link")), 5)
+            end
+        end),
+    }
+
+    local linked_text = link
+        and (T(_("Linked: %1"), Hardcover.linkLabel(book.filepath) or tostring(link.book_id)))
+        or _("Not linked to Hardcover")
+    dialog = require("ui/widget/buttondialog"):new{
+        title = _("Hardcover"),
+        buttons = {
+            { { text = linked_text, enabled = false } },
+            { embedded_button, select_book_button },
+            { select_edition_button, refresh_button },
+            { clear_button, { text = _("Cancel"), callback = function() UIManager:close(dialog) end } },
+        },
+    }
+    UIManager:show(dialog)
+end
+
 -- (from on_series_hold on a SeriesStack). Series groups have a .books field;
 -- we route to a series-specific dialog in that case.
 function BookshelfWidget:_openBookMenu(item)
@@ -7478,6 +7629,23 @@ function BookshelfWidget:_openBookMenu(item)
                 timeout = 2,
             })
         end),
+    }
+
+    local hardcover_button = {
+        text_func = function()
+            local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+            if ok_hc and Hardcover and Hardcover.getLink
+                    and Hardcover.getLink(book.filepath) then
+                return _("Hardcover") .. "  \xE2\x9C\x93"
+            end
+            return _("Hardcover")
+        end,
+        callback = function()
+            UIManager:close(dialog)
+            UIManager:nextTick(function()
+                bw:_openHardcoverMenu(book)
+            end)
+        end,
     }
 
     -- Rating button + sub-dialog. Sub-dialog writes draft.rating
@@ -7953,8 +8121,9 @@ function BookshelfWidget:_openBookMenu(item)
     --   1. Show info / Collections / Rating
     --   2. Status row (Unopened / Reading / On hold / Finished)
     --   3. Reset book data… / Remove from history
-    --   4. Delete / Refresh metadata
-    --   5. Select / Cancel / Apply
+    --   4. Refresh metadata / Hardcover
+    --   5. Delete
+    --   6. Select / Cancel / Apply
     --
     -- Top row pairs Show info / Collections / Rating so the Collections
     -- button sits right under the header pills (visual anchor to the
@@ -7964,7 +8133,8 @@ function BookshelfWidget:_openBookMenu(item)
         { show_info_button, tags_button, rating_button },
         status_row,
         { reset_btn,        remove_history_button, fav_button },
-        { delete_btn,       refresh_button },
+        { refresh_button,   hardcover_button },
+        { delete_btn },
     }
     buttons[#buttons + 1] = { select_btn, cancel_btn, apply_btn }
 

--- a/tests/_test_book_repository.lua
+++ b/tests/_test_book_repository.lua
@@ -280,6 +280,48 @@ test("buildBook: single-author string yields one-element array, no trailing whit
     assert(book.author == "Sole Author")
 end)
 
+test("buildBookMeta: Hardcover enrichment never sticks in sticky metadata cache", function()
+    local fp = "/hardcover-cache.epub"
+    _G._test_settings = {
+        bookshelf_hardcover_links = {
+            [fp] = { book_id = 123, title = "Remote Link" },
+        },
+        bookshelf_hardcover_enrichment = {
+            ["123"] = {
+                description = "Remote description",
+                cover_path = "/tmp/remote-cover.jpg",
+            },
+        },
+    }
+    local Hardcover = require("lib/bookshelf_hardcover")
+    Hardcover.invalidate()
+
+    _G._test_bim_data = {
+        [fp] = {
+            has_meta = "Y",
+            title = "Local Title",
+            authors = "Local Author",
+        },
+    }
+    local enriched = Repo.buildBookMeta(fp)
+    assert(enriched.description == "Remote description", "expected remote description")
+    assert(enriched.cover_image_path == "/tmp/remote-cover.jpg", "expected remote cover")
+
+    -- Simulate Clear link / Clear cache, then BIM being temporarily unable
+    -- to provide metadata. The fallback path should return a clean copy of
+    -- the sticky record, not stale Hardcover fields from before the unlink.
+    _G._test_settings.bookshelf_hardcover_links = {}
+    _G._test_settings.bookshelf_hardcover_enrichment = {}
+    Hardcover.invalidate()
+    _G._test_bim_data[fp] = {}
+
+    local fallback = Repo.buildBookMeta(fp)
+    assert(fallback.title == "Local Title", "sticky metadata record was not used")
+    assert(fallback.description == nil, "stale Hardcover description leaked")
+    assert(fallback.cover_image_path == nil, "stale Hardcover cover leaked")
+    assert(fallback.hardcover_book_id == nil, "stale Hardcover id leaked")
+end)
+
 test("buildBook: nil authors → nil array (not crash)", function()
     _G._test_bim_data = { ["/x.epub"] = {} }
     local book = Repo.buildBook("/x.epub")

--- a/tests/_test_book_repository.lua
+++ b/tests/_test_book_repository.lua
@@ -811,6 +811,58 @@ test("getAll: explicit drilldown path bypasses home_dir guard", function()
     assert(items[1].title == "X")
 end)
 
+test("getAll: hydrates Hardcover enrichment for book rows", function()
+    Repo.invalidateWalkCache()
+    local fp = "/lib/enriched.epub"
+    _G._test_settings = {
+        home_dir = "/lib",
+        bookshelf_latest_walk_depth = 1,
+        bookshelf_hardcover_links = {
+            [fp] = { book_id = 123, title = "Remote Link" },
+        },
+        bookshelf_hardcover_enrichment = {
+            ["123"] = {
+                description = "Remote description",
+                cover_path = "/tmp/remote-cover.jpg",
+            },
+        },
+    }
+    local Hardcover = require("lib/bookshelf_hardcover")
+    Hardcover.invalidate()
+    package.loaded["libs/libkoreader-lfs"].dir = function(path)
+        local files = (path == "/lib") and { ".", "..", "enriched.epub" } or {}
+        local i = 0
+        return function() i = i + 1; return files[i] end
+    end
+    package.loaded["libs/libkoreader-lfs"].attributes = function(_fp, key)
+        if key == "mode" then return "file" end
+        if key == "size" then return 100 end
+        if key == "modification" then return 0 end
+        return { mode = "file", size = 100, modification = 0 }
+    end
+    _G._test_bim_data = {
+        [fp] = {
+            has_meta = "Y",
+            title = "Local Title",
+            authors = "Local Author",
+        },
+    }
+
+    local items, total = Repo.getAll(nil, 10, 0)
+    assert(total == 1, "expected total=1, got " .. tostring(total))
+    assert(items and #items == 1, "expected one hydrated item")
+    assert(items[1].description == "Remote description", "missing Hardcover description")
+    assert(items[1].cover_image_path == "/tmp/remote-cover.jpg", "missing Hardcover cover")
+    assert(items[1].hardcover_book_id == 123, "missing Hardcover book id")
+
+    -- Second call exercises getAll's shape-cache HIT hydration path.
+    local cached_items, cached_total = Repo.getAll(nil, 10, 0)
+    assert(cached_total == 1, "expected cached total=1")
+    assert(cached_items and #cached_items == 1, "expected one cached hydrated item")
+    assert(cached_items[1].description == "Remote description", "cached path missed Hardcover description")
+    assert(cached_items[1].cover_image_path == "/tmp/remote-cover.jpg", "cached path missed Hardcover cover")
+end)
+
 test("getLatest: unset home_dir falls back to / and walks safely (denylist active)", function()
     Repo.invalidateWalkCache()
     -- home_dir nil → getLatest's `or "/"` fallback fires → walkBooks

--- a/tests/_test_hardcover.lua
+++ b/tests/_test_hardcover.lua
@@ -118,5 +118,28 @@ test("refreshBook writes cache from Hardcover API", function()
     assert(book.description == "Fresh Hardcover description.", tostring(book.description))
 end)
 
+test("refreshBookOnline uses KOReader network manager when available", function()
+    reset()
+    local network_called = false
+    package.loaded["ui/network/manager"] = {
+        runWhenOnline = function(_self, callback)
+            network_called = true
+            callback()
+        end,
+    }
+    assert(Hardcover.linkBook("/books/a.epub", { id = 123, title = "A Book" }))
+
+    local callback_ok, callback_payload
+    local ok = Hardcover.refreshBookOnline({ filepath = "/books/a.epub" }, {}, function(refresh_ok, payload)
+        callback_ok = refresh_ok
+        callback_payload = payload
+    end)
+    assert(ok == true, "online wrapper did not return true")
+    assert(network_called == true, "NetworkMgr:runWhenOnline was not used")
+    assert(callback_ok == true, tostring(callback_payload))
+    assert(callback_payload.description == "Fresh Hardcover description.", "bad callback payload")
+    package.loaded["ui/network/manager"] = nil
+end)
+
 io.stdout:write(("PASS %d  FAIL %d\n"):format(pass, fail))
 if fail > 0 then os.exit(1) end

--- a/tests/_test_hardcover.lua
+++ b/tests/_test_hardcover.lua
@@ -1,0 +1,122 @@
+-- tests/_test_hardcover.lua
+-- Pure-Lua tests for Bookshelf's optional Hardcover enrichment cache.
+
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local settings = {}
+
+package.loaded["lib/bookshelf_settings_store"] = {
+    read = function(key, default)
+        local v = settings["bookshelf_" .. key]
+        if v == nil then return default end
+        return v
+    end,
+    save = function(key, value)
+        settings["bookshelf_" .. key] = value
+    end,
+    delete = function(key)
+        settings["bookshelf_" .. key] = nil
+    end,
+    flush = function() end,
+    isTrue = function(key)
+        return settings["bookshelf_" .. key] == true
+    end,
+    nilOrTrue = function(key)
+        local v = settings["bookshelf_" .. key]
+        return v == nil or v == true
+    end,
+}
+
+package.loaded["datastorage"] = {
+    getSettingsDir = function() return "/tmp/bookshelf-hardcover-test" end,
+}
+
+package.loaded["libs/libkoreader-lfs"] = {
+    attributes = function() return nil end,
+}
+
+package.loaded["hardcover/lib/hardcover_api"] = {
+    query = function(_self, _query, variables)
+        return {
+            book = {
+                id = variables.bookId,
+                title = "Fresh Hardcover Title",
+                description = "Fresh Hardcover description.",
+            },
+        }
+    end,
+}
+
+local Hardcover = dofile("lib/bookshelf_hardcover.lua")
+
+local pass, fail = 0, 0
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        pass = pass + 1
+    else
+        fail = fail + 1
+        io.stderr:write("FAIL  " .. name .. "\n  " .. tostring(err) .. "\n")
+    end
+end
+
+local function reset()
+    settings = {}
+    Hardcover.invalidate()
+end
+
+test("linkBook stores a Bookshelf-owned link", function()
+    reset()
+    local ok, err = Hardcover.linkBook("/books/a.epub", {
+        id = 123,
+        title = "A Book",
+    })
+    assert(ok, tostring(err))
+    local link = Hardcover.getLink("/books/a.epub")
+    assert(link and link.book_id == 123, "missing book_id")
+    assert(link.title == "A Book", "missing title")
+end)
+
+test("enrichBook fills only missing description and missing cover", function()
+    reset()
+    assert(Hardcover.linkBook("/books/a.epub", { id = 123, title = "A Book" }))
+    settings.bookshelf_hardcover_enrichment = {
+        ["123"] = {
+            description = "Cached description.",
+            cover_path = "/tmp/cached-cover.jpg",
+        },
+    }
+    Hardcover.invalidate()
+
+    local book = Hardcover.enrichBook{
+        filepath = "/books/a.epub",
+        title = "A Book",
+        has_cover = false,
+    }
+    assert(book.description == "Cached description.", tostring(book.description))
+    assert(book.cover_image_path == "/tmp/cached-cover.jpg", tostring(book.cover_image_path))
+    assert(book.hardcover_description == true, "description marker missing")
+    assert(book.hardcover_cover == true, "cover marker missing")
+
+    local preserved = Hardcover.enrichBook{
+        filepath = "/books/a.epub",
+        description = "Local description.",
+        has_cover = true,
+    }
+    assert(preserved.description == "Local description.", "overwrote local description")
+    assert(preserved.cover_image_path == nil, "overwrote local cover")
+end)
+
+test("refreshBook writes cache from Hardcover API", function()
+    reset()
+    assert(Hardcover.linkBook("/books/a.epub", { id = 123, title = "A Book" }))
+    local ok, payload = Hardcover.refreshBook{ filepath = "/books/a.epub" }
+    assert(ok, tostring(payload))
+    assert(payload.description == "Fresh Hardcover description.", "bad payload")
+
+    local book = Hardcover.enrichBook{ filepath = "/books/a.epub", has_cover = false }
+    assert(book.description == "Fresh Hardcover description.", tostring(book.description))
+end)
+
+io.stdout:write(("PASS %d  FAIL %d\n"):format(pass, fail))
+if fail > 0 then os.exit(1) end


### PR DESCRIPTION
## Summary

- Add an optional Hardcover enrichment module that reuses existing hardcoverapp.koplugin links where present and keeps Bookshelf-owned links/cache as well.
- Add long-press Hardcover actions for linking embedded IDs, selecting a book or edition, refreshing metadata, and clearing a link.
- Fill missing descriptions and missing local covers from the local Hardcover cache only; shelf rendering never contacts the network and EPUB files are not modified.
- Add settings toggles plus a manual refresh/clear-cache surface, and document the workflow in the README.

## Testing

- luac -p lib/bookshelf_hardcover.lua lib/bookshelf_book_repository.lua lib/bookshelf_spine_widget.lua lib/bookshelf_settings.lua lib/bookshelf_widget.lua tests/_test_hardcover.lua
- lua tests/_test_hardcover.lua

## Notes

- Ratings and reviews are intentionally left out of this first PR so the starting point stays focused on cover images and descriptions.
- I did not rely on the full pure-Lua test suite for this branch because some existing tests currently fail locally for reasons outside this change, and some require KOReader UI stubs.