### PR TITLE
Add Hardcover ratings and reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ If you also use `hardcoverapp.koplugin`, Bookshelf can reuse its book links and 
 
 - Missing book descriptions can be filled from Hardcover.
 - Missing local EPUB covers can use cached Hardcover cover images as a Bookshelf-only fallback.
+- Cached Hardcover ratings can be shown in the hero rating row, and tapping that row opens a non-spoiler review popup.
 - Links are managed from a book's long-press menu under **Hardcover**.
-- Network calls only happen from explicit actions such as linking or **Settings -> Hardcover enrichment -> Refresh linked Hardcover metadata**. Normal shelf rendering reads only the local cache.
+- Network calls only happen from explicit actions such as linking, refreshing metadata/ratings, or opening reviews. Normal shelf rendering reads only the local cache.
 
 Bookshelf does not rewrite EPUB files. Hardcover descriptions and cover images are stored in Bookshelf's settings/cache and can be disabled or cleared from **Settings -> Hardcover enrichment**.
 
@@ -419,6 +420,8 @@ Tokens are placeholders prefixed with `%`. Conditional logic uses `[if:cond]…[
 | `%series_num` | *1* |
 | `%rating` | *★★★☆☆* (empty when unrated) |
 | `%rating_number` | *3* (1-5, empty when unrated) |
+| `%hardcover_rating` | *4.5* (cached Hardcover rating, empty when unavailable) |
+| `%hardcover_stars` | Cached Hardcover rating as star glyphs |
 | `%status` | *reading* (unread / reading / on_hold / finished) |
 | `%filename` | *The_Great_Gatsby* |
 | `%format` | *EPUB* |
@@ -513,8 +516,9 @@ Existing v1 settings migrate automatically on first launch -- legacy keys are re
 | `author_format` | `"auto"` / `"first_last"` / `"last_first"` -- author name display. |
 | `bookshelf_ui_font` | Chosen Bookshelf interface font (a resolvable font face). Absent = follow KOReader's UI font. |
 | `cover_cache_mb` | Memory budget (MB) for the scaled-cover cache (default 24). The legacy `cover_cache_size` count key is discarded on first load. |
-| `hardcover_links` / `hardcover_enrichment` | Optional Hardcover link and cached description/cover metadata used by the Hardcover enrichment menu. |
+| `hardcover_links` / `hardcover_enrichment` / `hardcover_ratings` / `hardcover_reviews` | Optional Hardcover link and cached description/cover/rating/review metadata used by the Hardcover enrichment menu. |
 | `hardcover_fill_descriptions` / `hardcover_fill_covers` | Optional toggles for whether cached Hardcover descriptions/covers fill missing local metadata. Defaults on. |
+| `hardcover_hero_rating` | Show cached Hardcover ratings in the hero rating row instead of KOReader's local rating. |
 | `calibre_metadata` | BETA. Read metadata from `metadata.calibre` if present. |
 | `latest_walk_depth` | How deep the **Latest** source scans your library. |
 | `show_close_msg` | Show the centred "Closing book…" toast when exiting a book. |

--- a/lib/bookshelf_hardcover.lua
+++ b/lib/bookshelf_hardcover.lua
@@ -13,10 +13,16 @@ local Hardcover = {}
 local HC_SETTINGS_FILE = "hardcoversync_settings.lua"
 local LINKS_KEY        = "hardcover_links"
 local CACHE_KEY        = "hardcover_enrichment"
+local RATINGS_KEY      = "hardcover_ratings"
+local RATINGS_TIME_KEY = "hardcover_ratings_fetched_at"
+local REVIEWS_KEY      = "hardcover_reviews"
+local REVIEWS_TTL      = 24 * 60 * 60
 
 local _links
 local _external_links
 local _enrichment_cache
+local _ratings_cache
+local _reviews_cache
 local _hc_settings
 local _hc_settings_object
 
@@ -88,6 +94,38 @@ end
 local function _saveEnrichmentCache(cache)
     _enrichment_cache = cache or {}
     BookshelfSettings.save(CACHE_KEY, _enrichment_cache)
+end
+
+local function _readRatingsCache()
+    if _ratings_cache then return _ratings_cache end
+    local raw = BookshelfSettings.read(RATINGS_KEY, {})
+    _ratings_cache = type(raw) == "table" and raw or {}
+    return _ratings_cache
+end
+
+local function _saveRatingsCache(cache)
+    _ratings_cache = cache or {}
+    BookshelfSettings.save(RATINGS_KEY, _ratings_cache)
+    BookshelfSettings.save(RATINGS_TIME_KEY, os.time())
+end
+
+local function _readReviewsCache()
+    if _reviews_cache then return _reviews_cache end
+    local raw = BookshelfSettings.read(REVIEWS_KEY, {})
+    _reviews_cache = type(raw) == "table" and raw or {}
+    return _reviews_cache
+end
+
+local function _saveReviewsCache(cache)
+    _reviews_cache = cache or {}
+    BookshelfSettings.save(REVIEWS_KEY, _reviews_cache)
+end
+
+local function _ratingFromCacheEntry(entry)
+    if type(entry) ~= "table" then return nil end
+    local rating = entry.rating
+    if rating == false then return nil end
+    return tonumber(rating)
 end
 
 local function _cacheKey(book_id, edition_id)
@@ -355,8 +393,40 @@ function Hardcover.invalidate()
     _links = nil
     _external_links = nil
     _enrichment_cache = nil
+    _ratings_cache = nil
+    _reviews_cache = nil
     _hc_settings = nil
     _hc_settings_object = nil
+end
+
+function Hardcover.getCachedAt()
+    return tonumber(BookshelfSettings.read(RATINGS_TIME_KEY))
+end
+
+function Hardcover.getCacheStats()
+    local cache = _readRatingsCache()
+    local linked, rated = 0, 0
+    local seen = {}
+    local function countLink(_filepath, link)
+        if type(link) ~= "table" or not link.book_id then return end
+        local key = tostring(link.book_id)
+        if seen[key] then return end
+        seen[key] = true
+        linked = linked + 1
+        if _ratingFromCacheEntry(cache[key]) then rated = rated + 1 end
+    end
+    for fp, link in pairs(_readExternalLinks(false)) do countLink(fp, link) end
+    for fp, link in pairs(_readLinks()) do countLink(fp, link) end
+    return {
+        linked = linked,
+        rated = rated,
+        fetched_at = Hardcover.getCachedAt(),
+    }
+end
+
+function Hardcover.getCachedRating(book_id)
+    if not book_id then return nil end
+    return _ratingFromCacheEntry(_readRatingsCache()[tostring(book_id)])
 end
 
 function Hardcover.clearEnrichmentCache()
@@ -374,6 +444,16 @@ function Hardcover.clearEnrichmentCache()
             end
         end
     end
+end
+
+function Hardcover.clearRatingsCache()
+    _ratings_cache = {}
+    BookshelfSettings.save(RATINGS_KEY, _ratings_cache)
+    BookshelfSettings.delete(RATINGS_TIME_KEY)
+end
+
+function Hardcover.clearReviewsCache()
+    _saveReviewsCache({})
 end
 
 function Hardcover.getLink(filepath)
@@ -652,6 +732,45 @@ local function _errString(err)
     return tostring(err)
 end
 
+local function _collectLinkedBookIds()
+    local ids, seen = {}, {}
+    local function collect(_filepath, link)
+        if type(link) ~= "table" or not link.book_id then return end
+        local id = tonumber(link.book_id)
+        if id and not seen[id] then
+            seen[id] = true
+            ids[#ids + 1] = id
+        end
+    end
+    for fp, link in pairs(_readExternalLinks(true)) do collect(fp, link) end
+    for fp, link in pairs(_readLinks()) do collect(fp, link) end
+    table.sort(ids)
+    return ids
+end
+
+local function _getUserId(Api, settings)
+    if not settings then return nil, "Could not open Hardcover settings" end
+    local user_id = settings:readSetting("user_id")
+    if user_id then return tonumber(user_id) or user_id end
+    if type(Api.me) ~= "function" then return nil, "Hardcover user id is missing" end
+    local ok_me, me = pcall(Api.me, Api)
+    if not ok_me then
+        return nil, "Could not fetch Hardcover user id: " .. _errString(me)
+    end
+    user_id = me and me.id
+    if not user_id then return nil, "Could not fetch Hardcover user id" end
+    pcall(settings.saveSetting, settings, "user_id", user_id)
+    if type(settings.flush) == "function" then
+        pcall(settings.flush, settings)
+    end
+    return tonumber(user_id) or user_id
+end
+
+local function _normaliseUserName(user)
+    if type(user) ~= "table" then return nil end
+    return user.name or user.username
+end
+
 local function _imageUrl(row)
     if type(row) ~= "table" then return nil end
     if type(row.cached_image) == "string" and row.cached_image ~= "" then
@@ -870,6 +989,199 @@ function Hardcover.refreshAllLinkedOnline(callback)
     end)
 end
 
+local function _normaliseReviewsPayload(book)
+    if type(book) ~= "table" then return nil end
+    local reviews = {}
+    for _, row in ipairs(type(book.user_books) == "table" and book.user_books or {}) do
+        local text = row.review or row.review_raw
+        if type(text) == "string" and text ~= "" then
+            reviews[#reviews + 1] = {
+                id = row.id,
+                rating = tonumber(row.rating),
+                text = text,
+                spoiler = row.review_has_spoilers == true,
+                reviewed_at = row.reviewed_at,
+                likes_count = tonumber(row.likes_count) or 0,
+                user_name = _normaliseUserName(row.user),
+                username = type(row.user) == "table" and row.user.username or nil,
+            }
+        end
+    end
+    return {
+        book_id = book.id,
+        title = book.title,
+        rating = tonumber(book.rating),
+        ratings_count = tonumber(book.ratings_count) or 0,
+        reviews_count = tonumber(book.reviews_count) or 0,
+        reviews = reviews,
+        fetched_at = os.time(),
+    }
+end
+
+function Hardcover.fetchReviews(book_id, opts)
+    opts = opts or {}
+    book_id = tonumber(book_id) or book_id
+    if not book_id then return false, "Missing Hardcover book id" end
+
+    local key = tostring(book_id)
+    local cache = _readReviewsCache()
+    local cached = cache[key]
+    local ttl = tonumber(opts.ttl) or REVIEWS_TTL
+    if not opts.force and type(cached) == "table" and cached.fetched_at
+            and (os.time() - tonumber(cached.fetched_at)) < ttl then
+        return true, cached
+    end
+
+    local Api, api_err = _loadApi()
+    if not Api then return false, api_err end
+
+    local limit = tonumber(opts.limit) or 10
+    if limit < 1 then limit = 1 end
+    if limit > 25 then limit = 25 end
+
+    local query = [[
+        query ($id: Int!, $limit: Int!) {
+          books_by_pk(id: $id) {
+            id
+            title
+            rating
+            ratings_count
+            reviews_count
+            user_books(
+              where: { has_review: { _eq: true }, review_has_spoilers: { _eq: false } },
+              order_by: [{ likes_count: desc_nulls_last }, { reviewed_at: desc_nulls_last }],
+              limit: $limit
+            ) {
+              id
+              rating
+              review
+              review_raw
+              review_has_spoilers
+              reviewed_at
+              likes_count
+              user {
+                id
+                name
+                username
+              }
+            }
+          }
+        }
+    ]]
+
+    local ok_query, data, err = pcall(Api.query, Api, query, { id = book_id, limit = limit })
+    if not ok_query then
+        return false, "Hardcover reviews could not be fetched: " .. _errString(data)
+    end
+    if not data or type(data.books_by_pk) ~= "table" then
+        return false, err and ("Hardcover reviews could not be fetched: " .. _errString(err))
+            or "No response from Hardcover"
+    end
+
+    local payload = _normaliseReviewsPayload(data.books_by_pk)
+    if not payload then return false, "Hardcover reviews could not be parsed" end
+    cache[key] = payload
+    _saveReviewsCache(cache)
+    return true, payload
+end
+
+function Hardcover.fetchReviewsOnline(book_id, opts, callback)
+    opts = opts or {}
+    return _runWhenOnline(function()
+        local ok, payload = Hardcover.fetchReviews(book_id, opts)
+        if callback then callback(ok, payload) end
+    end, function(err)
+        if callback then callback(false, err) end
+    end)
+end
+
+function Hardcover.refreshRatings()
+    local Api, api_err = _loadApi()
+    if not Api then return false, api_err end
+
+    local ok_settings, settings = pcall(_openExternalSettings)
+    if not ok_settings or not settings then
+        return false, "Could not open Hardcover settings"
+    end
+
+    local ids = _collectLinkedBookIds()
+    if #ids == 0 then
+        _saveRatingsCache({})
+        return true, {
+            linked = 0,
+            rated = 0,
+            updated = 0,
+        }
+    end
+
+    local user_id, user_err = _getUserId(Api, settings)
+    if not user_id then return false, user_err end
+
+    local query = [[
+        query ($ids: [Int!], $userId: Int!) {
+          books(where: { id: { _in: $ids }}) {
+            id
+            rating
+            ratings_count
+            reviews_count
+            user_books(where: { user_id: { _eq: $userId }}) {
+              id
+              rating
+            }
+          }
+        }
+    ]]
+
+    local ok_query, data, err = pcall(Api.query, Api, query, { ids = ids, userId = user_id })
+    if not ok_query then
+        return false, "Hardcover rating refresh failed: " .. _errString(data)
+    end
+    if not data or type(data.books) ~= "table" then
+        return false, err and ("Hardcover rating refresh failed: " .. _errString(err))
+            or "No response from Hardcover"
+    end
+
+    local now = os.time()
+    local cache = {}
+    for _, id in ipairs(ids) do
+        cache[tostring(id)] = { rating = false, fetched_at = now }
+    end
+
+    local rated = 0
+    for _, row in ipairs(data.books) do
+        if type(row) == "table" and row.id then
+            local rating = tonumber(row.rating)
+            local user_book = type(row.user_books) == "table" and row.user_books[1] or nil
+            local user_rating = user_book and tonumber(user_book.rating) or nil
+            if rating then rated = rated + 1 end
+            cache[tostring(row.id)] = {
+                rating = rating or false,
+                ratings_count = tonumber(row.ratings_count) or 0,
+                reviews_count = tonumber(row.reviews_count) or 0,
+                user_book_id = user_book and user_book.id or nil,
+                user_rating = user_rating or false,
+                fetched_at = now,
+            }
+        end
+    end
+
+    _saveRatingsCache(cache)
+    return true, {
+        linked = #ids,
+        rated = rated,
+        updated = #data.books,
+    }
+end
+
+function Hardcover.refreshRatingsOnline(callback)
+    return _runWhenOnline(function()
+        local ok, stats = Hardcover.refreshRatings()
+        if callback then callback(ok, stats) end
+    end, function(err)
+        if callback then callback(false, err) end
+    end)
+end
+
 function Hardcover.enrichBook(book)
     if not book or not book.filepath then return book end
     local link = Hardcover.getLink(book.filepath)
@@ -878,6 +1190,13 @@ function Hardcover.enrichBook(book)
     book.hardcover_book_id = tonumber(link.book_id) or link.book_id
     book.hardcover_edition_id = tonumber(link.edition_id) or link.edition_id
     book.hardcover_title = link.title
+
+    local rating_entry = _readRatingsCache()[tostring(link.book_id)]
+    book.hardcover_rating = Hardcover.getCachedRating(link.book_id)
+    if type(rating_entry) == "table" then
+        book.hardcover_ratings_count = tonumber(rating_entry.ratings_count) or 0
+        book.hardcover_reviews_count = tonumber(rating_entry.reviews_count) or 0
+    end
 
     local enrichment = Hardcover.getCachedEnrichment(link.book_id, link.edition_id)
     if type(enrichment) ~= "table" then return book end

--- a/lib/bookshelf_hero_card.lua
+++ b/lib/bookshelf_hero_card.lua
@@ -33,6 +33,10 @@ local HeroBar         = require("lib/bookshelf_hero_bar")
 local TextSegments    = require("lib/bookshelf_text_segments")
 local RenderText      = require("ui/rendertext")
 
+local HC_STAR       = "\xef\x80\x85" -- Nerd Font nf-fa-star
+local HC_HALF_STAR  = "\xef\x82\x89" -- Nerd Font nf-fa-star_half
+local HC_EMPTY_STAR = "\xef\x80\x86" -- Nerd Font nf-fa-star_o
+
 local HeroCard = InputContainer:extend{
     book                = nil,
     width               = nil,
@@ -54,6 +58,10 @@ local HeroCard = InputContainer:extend{
     -- is responsible for persisting to DocSettings and triggering a
     -- hero rebuild.
     on_rating_change    = nil,
+    -- Fires when the user taps the display-only Hardcover rating row.
+    -- The parent fetches/shows reviews explicitly so normal hero
+    -- rendering remains cache-only and offline.
+    on_hardcover_reviews_tap = nil,
     is_selected         = false,
     is_bulk_selected    = false,
     -- Builder callback returning a fresh tappable pill-strip widget for
@@ -557,56 +565,106 @@ function HeroCard:_buildRightColumn(book, regions, state, dimen)
     -- Sits ABOVE title/author so the stars anchor to a fixed y position
     -- regardless of how long the title is or whether the author line is
     -- present -- predictable target for tap-to-rate.
-    if regions.rating and not regions.rating.disabled and book and self.on_rating_change then
-        -- 1.25x nominal font size so the glyph reads as a clear
-        -- interactive target while staying close in scale to the
-        -- old IconWidget render (scaleBySize(16), ~24px on PW5).
-        local star_size = regions.rating.font_size or 16
-        local face      = fontFace(nil, math.floor(star_size * 1.25 + 0.5))
-        local gap       = Screen:scaleBySize(4)
-        local rating    = tonumber(book.rating) or 0
-        local row       = HorizontalGroup:new{ align = "center" }
-        local hero_self = self
-        for i = 1, 5 do
-            local glyph = (i <= rating) and "\xE2\x98\x85" or "\xE2\x98\x86"
-            local tw = TextWidget:new{
-                text = glyph,
-                face = face,
-                bold = true,
-            }
-            local sz = tw:getSize()
-            local Star = InputContainer:extend{}
-            function Star:onTap()
-                -- Tapping the current rating clears it (matches KOReader's
-                -- BookStatusWidget toggle behaviour).
-                --
-                -- Lua ternary gotcha: `(cond) and nil or i` always
-                -- returns `i`, because `cond and nil` evaluates to nil
-                -- (a falsy value) and the `or i` branch wins. Have to
-                -- use an explicit if/else (or `(cond) and (something
-                -- truthy) or fallback`).
-                local new_rating
-                if i == rating then
-                    new_rating = nil
+    if regions.rating and not regions.rating.disabled and book then
+        local hardcover_mode = BookshelfSettings.isTrue("hardcover_hero_rating")
+        local rating
+        if hardcover_mode then
+            rating = tonumber(book.hardcover_rating)
+        else
+            rating = tonumber(book.rating) or 0
+        end
+        if (hardcover_mode or self.on_rating_change) and (not hardcover_mode or rating) then
+            local star_size = regions.rating.font_size or 16
+            local face      = fontFace(nil, hardcover_mode and star_size
+                or math.floor(star_size * 1.25 + 0.5))
+            local gap       = Screen:scaleBySize(4)
+            local row       = HorizontalGroup:new{ align = "center" }
+            local hero_self = self
+            for i = 1, 5 do
+                local glyph
+                if hardcover_mode then
+                    local whole = math.floor(rating)
+                    if i <= whole then
+                        glyph = HC_STAR
+                    elseif i == whole + 1 and rating - whole >= 0.5 then
+                        glyph = HC_HALF_STAR
+                    else
+                        glyph = HC_EMPTY_STAR
+                    end
                 else
-                    new_rating = i
+                    glyph = (i <= rating) and "\xE2\x98\x85" or "\xE2\x98\x86"
                 end
-                hero_self.on_rating_change(hero_self.book, new_rating)
-                return true
+                local tw = TextWidget:new{
+                    text = glyph,
+                    face = face,
+                    bold = true,
+                }
+                local sz = tw:getSize()
+                if hardcover_mode or not self.on_rating_change then
+                    row[#row + 1] = tw
+                else
+                    local Star = InputContainer:extend{}
+                    function Star:onTap()
+                        -- Tapping the current rating clears it (matches KOReader's
+                        -- BookStatusWidget toggle behaviour).
+                        local new_rating
+                        if i == rating then
+                            new_rating = nil
+                        else
+                            new_rating = i
+                        end
+                        hero_self.on_rating_change(hero_self.book, new_rating)
+                        return true
+                    end
+                    local star = Star:new{
+                        dimen = Geom:new{ w = sz.w, h = sz.h },
+                        tw,
+                    }
+                    star.ges_events = {
+                        Tap = { GestureRange:new{ ges = "tap", range = star.dimen } },
+                    }
+                    row[#row + 1] = star
+                end
+                if i < 5 then
+                    row[#row + 1] = HorizontalSpan:new{ width = gap }
+                end
             end
-            local star = Star:new{
-                dimen = Geom:new{ w = sz.w, h = sz.h },
-                tw,
-            }
-            star.ges_events = {
-                Tap = { GestureRange:new{ ges = "tap", range = star.dimen } },
-            }
-            row[#row + 1] = star
-            if i < 5 then
-                row[#row + 1] = HorizontalSpan:new{ width = gap }
+            if hardcover_mode then
+                local reviews_count = tonumber(book.hardcover_reviews_count)
+                if reviews_count and reviews_count > 0 then
+                    row[#row + 1] = HorizontalSpan:new{ width = gap * 2 }
+                    row[#row + 1] = TextWidget:new{
+                        text = string.format("%d reviews", reviews_count),
+                        face = fontFace(nil, math.max(10, math.floor(star_size * 0.65 + 0.5))),
+                        bold = true,
+                    }
+                end
+                if self.on_hardcover_reviews_tap then
+                    local RatingTap = InputContainer:extend{}
+                    local hero = self
+                    function RatingTap:onTap()
+                        hero.on_hardcover_reviews_tap(hero.book)
+                        return true
+                    end
+                    local row_size = row:getSize()
+                    local tappable = RatingTap:new{
+                        dimen = Geom:new{
+                            w = right_w,
+                            h = row_size and row_size.h or star_size,
+                        },
+                        row,
+                    }
+                    tappable.ges_events = {
+                        Tap = { GestureRange:new{ ges = "tap", range = tappable.dimen } },
+                    }
+                    right_top[#right_top + 1] = tappable
+                else
+                    right_top[#right_top + 1] = row
+                end
+            else
+                right_top[#right_top + 1] = row
             end
         end
-        right_top[#right_top + 1] = row
     end
 
     -- Title (rendered after rating so the stars sit at a fixed y above it).

--- a/lib/bookshelf_settings.lua
+++ b/lib/bookshelf_settings.lua
@@ -1141,6 +1141,12 @@ function Settings:_settingsSubItems()
     }
 end
 
+local function _formatCacheTime(ts)
+    ts = tonumber(ts)
+    if not ts then return _("never") end
+    return os.date("%Y-%m-%d %H:%M", ts)
+end
+
 function Settings:_hardcoverSubItems()
     local function markDirty(reason)
         pcall(function()
@@ -1163,6 +1169,20 @@ function Settings:_hardcoverSubItems()
     end
 
     return {
+        {
+            text_func = function()
+                local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+                if not ok_hc or not Hardcover or not Hardcover.getCacheStats then
+                    return _("Cached Hardcover ratings: unavailable")
+                end
+                local stats = Hardcover.getCacheStats()
+                return string.format(_("Cached Hardcover ratings: %d/%d · %s"),
+                    stats.rated or 0,
+                    stats.linked or 0,
+                    _formatCacheTime(stats.fetched_at))
+            end,
+            enabled_func = function() return false end,
+        },
         {
             text = _("Fill missing descriptions from Hardcover"),
             help_text = _("When a book is linked to Hardcover and Bookshelf has cached a description for it, use that text only if the EPUB has no description of its own."),
@@ -1187,6 +1207,58 @@ function Settings:_hardcoverSubItems()
                 local enabled = BookshelfSettings.nilOrTrue("hardcover_fill_covers")
                 BookshelfSettings.save("hardcover_fill_covers", not enabled)
                 markDirty("hardcover-cover-toggle")
+            end,
+        },
+        {
+            text = _("Show Hardcover ratings in hero"),
+            help_text = _("When enabled, the Hero rating row shows the cached public Hardcover rating instead of KOReader's local rating. Enabling this also turns on the Hero rating row. Normal Bookshelf rendering only reads the local cache."),
+            checked_func = function()
+                return BookshelfSettings.isTrue("hardcover_hero_rating")
+            end,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                local enabled = BookshelfSettings.isTrue("hardcover_hero_rating")
+                BookshelfSettings.save("hardcover_hero_rating", not enabled)
+                if not enabled then
+                    local Regions = require("lib/bookshelf_hero_regions")
+                    local regions = Regions.read()
+                    if regions.rating and regions.rating.disabled then
+                        regions.rating.disabled = false
+                        Regions.write("rating", regions.rating)
+                    end
+                end
+                if touchmenu_instance and touchmenu_instance.updateItems then
+                    touchmenu_instance:updateItems()
+                end
+                markDirty("hardcover-rating-toggle")
+            end,
+        },
+        {
+            text = _("Refresh Hardcover ratings"),
+            help_text = _("Fetch public ratings and review counts for linked Hardcover books and store them in Bookshelf's local cache."),
+            callback = function(touchmenu_instance)
+                if touchmenu_instance then
+                    UIManager:close(touchmenu_instance)
+                end
+                UIManager:nextTick(function()
+                    local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+                    if not ok_hc or not Hardcover or not Hardcover.refreshRatingsOnline then
+                        notify(_("Hardcover integration could not be loaded"))
+                        return
+                    end
+                    notify(_("Fetching Hardcover ratings..."), 1)
+                    Hardcover.refreshRatingsOnline(function(ok, stats)
+                        if not ok then
+                            notify(tostring(stats or _("Hardcover ratings refresh failed")), 5)
+                            return
+                        end
+                        markDirty("hardcover-ratings-refresh")
+                        stats = type(stats) == "table" and stats or {}
+                        notify(T(_("Hardcover ratings refreshed: %1 rated of %2 linked books"),
+                                 tostring(stats.rated or 0),
+                                 tostring(stats.linked or 0)), 4)
+                    end)
+                end)
             end,
         },
         {
@@ -1229,6 +1301,24 @@ function Settings:_hardcoverSubItems()
                     end
                     markDirty("hardcover-clear-cache")
                     notify(_("Hardcover cache cleared"))
+                end)
+            end,
+        },
+        {
+            text = _("Clear cached Hardcover ratings/reviews"),
+            help_text = _("Remove Bookshelf's cached Hardcover ratings, review counts, and review text. Existing links and cached descriptions/covers are kept."),
+            callback = function(touchmenu_instance)
+                if touchmenu_instance then
+                    UIManager:close(touchmenu_instance)
+                end
+                UIManager:nextTick(function()
+                    local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+                    if ok_hc and Hardcover then
+                        if Hardcover.clearRatingsCache then Hardcover.clearRatingsCache() end
+                        if Hardcover.clearReviewsCache then Hardcover.clearReviewsCache() end
+                    end
+                    markDirty("hardcover-ratings-clear-cache")
+                    notify(_("Hardcover ratings/reviews cache cleared"))
                 end)
             end,
         },

--- a/lib/bookshelf_tokens.lua
+++ b/lib/bookshelf_tokens.lua
@@ -36,6 +36,8 @@ Tokens.CATALOGUE = {
     { category = "Book",     token = "%series_num",       description = "Series number" },
     { category = "Book",     token = "%rating",           description = "Star rating (★★★☆☆), empty when unrated" },
     { category = "Book",     token = "%rating_number",    description = "Rating as a number 1-5 (empty when unrated)" },
+    { category = "Book",     token = "%hardcover_rating", description = "Cached Hardcover rating number" },
+    { category = "Book",     token = "%hardcover_stars",  description = "Cached Hardcover rating as stars" },
     { category = "Book",     token = "%status",           description = "Reading status (unread / reading / on_hold / finished)" },
     { category = "Book",     token = "%filename",         description = "File name" },
     { category = "Book",     token = "%format",           description = "Format (EPUB/PDF/…)" },
@@ -186,6 +188,36 @@ Tokens.expanders.rating = function(book)
     local filled = "\xE2\x98\x85"  -- ★ U+2605
     local empty  = "\xE2\x98\x86"  -- ☆ U+2606
     return filled:rep(r) .. empty:rep(5 - r)
+end
+
+local HC_STAR       = "\xef\x80\x85" -- Nerd Font nf-fa-star
+local HC_HALF_STAR  = "\xef\x82\x89" -- Nerd Font nf-fa-star_half
+local HC_EMPTY_STAR = "\xef\x80\x86" -- Nerd Font nf-fa-star_o
+
+Tokens.expanders.hardcover_rating = function(book)
+    if not book or not book.hardcover_rating then return "" end
+    local r = tonumber(book.hardcover_rating)
+    if not r or r <= 0 then return "" end
+    return string.format("%.1f", r):gsub("%.0$", "")
+end
+
+Tokens.expanders.hardcover_stars = function(book)
+    if not book or not book.hardcover_rating then return "" end
+    local r = tonumber(book.hardcover_rating)
+    if not r or r <= 0 then return "" end
+    if r > 5 then r = 5 end
+    local whole = math.floor(r)
+    local out = {}
+    for i = 1, 5 do
+        if i <= whole then
+            out[#out + 1] = HC_STAR
+        elseif i == whole + 1 and r - whole >= 0.5 then
+            out[#out + 1] = HC_HALF_STAR
+        else
+            out[#out + 1] = HC_EMPTY_STAR
+        end
+    end
+    return table.concat(out)
 end
 
 local function codepointToUtf8(n)

--- a/lib/bookshelf_widget.lua
+++ b/lib/bookshelf_widget.lua
@@ -2642,6 +2642,7 @@ function BookshelfWidget:_buildHero(content_w, hero_cover_w, hero_cover_h, hero_
         end,
         on_description_tap = function(b) self:_showFullDescription(b) end,
         on_rating_change   = function(b, r) self:_setBookRating(b, r) end,
+        on_hardcover_reviews_tap = function(b) self:_showHardcoverReviews(b) end,
         is_selected      = (self._focus_zone == "hero")
                            or (current and self._selection:contains(current.filepath) or false)
                            or (current and self._tap_selected_fp == current.filepath or false),
@@ -7190,6 +7191,199 @@ function BookshelfWidget:_showFullDescription(book)
     UIManager:show(viewer)
 end
 
+local function _formatHardcoverReviewRating(rating)
+    rating = tonumber(rating)
+    if not rating or rating <= 0 then return nil end
+    local text = string.format("%.1f", rating):gsub("%.0$", "")
+    return text .. " \xE2\x98\x85"
+end
+
+local function _formatHardcoverReviewDate(ts)
+    if type(ts) ~= "string" then return nil end
+    return ts:match("^(%d%d%d%d%-%d%d%-%d%d)") or ts
+end
+
+local function _repaintHardcoverReviewViewer(viewer)
+    UIManager:setDirty(viewer, function()
+        if viewer and viewer.dimen then
+            return "ui", viewer.dimen
+        end
+        return "full"
+    end)
+end
+
+local function _scrollHardcoverReviewViewer(viewer, direction)
+    local scroll = viewer and viewer.scroll_text_w
+    local textw = scroll and scroll.text_widget
+    if not textw or not textw.vertical_string_list or not textw.lines_per_page then
+        return true
+    end
+
+    local line_count = #textw.vertical_string_list
+    local lines_per_page = math.max(1, tonumber(textw.lines_per_page) or 1)
+    local max_top = math.max(1, line_count - lines_per_page + 1)
+    local old_top = math.max(1, tonumber(textw.virtual_line_num) or 1)
+    local new_top = old_top + (direction > 0 and lines_per_page or -lines_per_page)
+    if new_top < 1 then
+        new_top = 1
+    elseif new_top > max_top then
+        new_top = max_top
+    end
+
+    if new_top ~= old_top then
+        textw.image_show_alt_text = nil
+        textw:free(false)
+        textw.virtual_line_num = new_top
+        textw:_updateLayout()
+        if scroll.updateScrollBar then
+            scroll:updateScrollBar(true)
+        end
+        _repaintHardcoverReviewViewer(viewer)
+    end
+    return true
+end
+
+local function _stabiliseHardcoverReviewViewer(viewer)
+    local scroll = viewer and viewer.scroll_text_w
+    if not scroll then return end
+
+    -- TextViewer can advance read-only text past the last full page on
+    -- some KOReader builds. Clamp page turns so reviews don't become blank.
+    function scroll:scrollDown()
+        return _scrollHardcoverReviewViewer(viewer, 1)
+    end
+    function scroll:scrollUp()
+        return _scrollHardcoverReviewViewer(viewer, -1)
+    end
+    function scroll:scrollText(direction)
+        return _scrollHardcoverReviewViewer(viewer, direction)
+    end
+    function scroll:onScrollDown()
+        return _scrollHardcoverReviewViewer(viewer, 1)
+    end
+    function scroll:onScrollUp()
+        return _scrollHardcoverReviewViewer(viewer, -1)
+    end
+
+    if Device:hasKeys() then
+        viewer.key_events = viewer.key_events or {}
+        viewer.key_events.BSHardcoverReviewsNextPage = { { Device.input.group.PgFwd } }
+        viewer.key_events.BSHardcoverReviewsPrevPage = { { Device.input.group.PgBack } }
+        function viewer:onBSHardcoverReviewsNextPage()
+            return _scrollHardcoverReviewViewer(viewer, 1)
+        end
+        function viewer:onBSHardcoverReviewsPrevPage()
+            return _scrollHardcoverReviewViewer(viewer, -1)
+        end
+    end
+end
+
+function BookshelfWidget:_showHardcoverReviews(book, opts)
+    opts = opts or {}
+    if not (book and book.filepath) then return end
+    local ok_hc, Hardcover = pcall(require, "lib/bookshelf_hardcover")
+    local InfoMessage = require("ui/widget/infomessage")
+    if not ok_hc or not Hardcover then
+        UIManager:show(InfoMessage:new{
+            text = _("Hardcover integration could not be loaded"),
+            icon = "notice-warning",
+            timeout = 3,
+        })
+        return
+    end
+
+    local link = Hardcover.getLink(book.filepath)
+    local book_id = book.hardcover_book_id or (link and link.book_id)
+    if not book_id then
+        UIManager:show(InfoMessage:new{
+            text = _("No Hardcover book is linked yet."),
+            icon = "notice-warning",
+            timeout = 3,
+        })
+        return
+    end
+
+    UIManager:show(InfoMessage:new{
+        text = _("Fetching Hardcover reviews..."),
+        timeout = 1,
+    })
+
+    Hardcover.fetchReviewsOnline(book_id, {
+        force = opts.force == true,
+    }, function(ok, result)
+        if not ok then
+            UIManager:show(InfoMessage:new{
+                text = _("Hardcover reviews could not be fetched: ") .. tostring(result),
+                icon = "notice-warning",
+                timeout = 5,
+            })
+            return
+        end
+
+        local Tokens = require("lib/bookshelf_tokens")
+        local parts = {}
+        local title = result.title or book.hardcover_title or book.title or _("Hardcover reviews")
+        parts[#parts + 1] = title
+
+        local meta = {}
+        local rating = _formatHardcoverReviewRating(result.rating)
+        if rating then meta[#meta + 1] = rating end
+        if tonumber(result.ratings_count) and tonumber(result.ratings_count) > 0 then
+            meta[#meta + 1] = string.format(_("%d ratings"), tonumber(result.ratings_count))
+        end
+        if tonumber(result.reviews_count) and tonumber(result.reviews_count) > 0 then
+            meta[#meta + 1] = string.format(_("%d reviews"), tonumber(result.reviews_count))
+        end
+        if #meta > 0 then
+            parts[#parts + 1] = table.concat(meta, " · ")
+        end
+        parts[#parts + 1] = _("Showing non-spoiler reviews from Hardcover.")
+
+        local reviews = type(result.reviews) == "table" and result.reviews or {}
+        if #reviews == 0 then
+            parts[#parts + 1] = ""
+            parts[#parts + 1] = _("No non-spoiler reviews found.")
+        else
+            for _i, review in ipairs(reviews) do
+                parts[#parts + 1] = ""
+                parts[#parts + 1] = "--------------------"
+                local line = {}
+                line[#line + 1] = review.user_name or review.username or _("Unknown reader")
+                local r = _formatHardcoverReviewRating(review.rating)
+                if r then line[#line + 1] = r end
+                local d = _formatHardcoverReviewDate(review.reviewed_at)
+                if d then line[#line + 1] = d end
+                if tonumber(review.likes_count) and tonumber(review.likes_count) > 0 then
+                    line[#line + 1] = string.format(_("%d likes"), tonumber(review.likes_count))
+                end
+                parts[#parts + 1] = table.concat(line, " · ")
+                local text = Tokens.cleanDescription(review.text or "") or ""
+                if text == "" then text = _("No review text.") end
+                parts[#parts + 1] = text
+            end
+        end
+
+        local viewer
+        viewer = require("ui/widget/textviewer"):new{
+            title = _("Hardcover reviews"),
+            text  = table.concat(parts, "\n"),
+            buttons_table = {
+                {
+                    { text = _("Refresh"), callback = function()
+                        UIManager:close(viewer)
+                        self:_showHardcoverReviews(book, { force = true })
+                    end },
+                    { text = _("Close"), callback = function()
+                        UIManager:close(viewer)
+                    end },
+                },
+            },
+        }
+        _stabiliseHardcoverReviewViewer(viewer)
+        UIManager:show(viewer)
+    end)
+end
+
 function BookshelfWidget:_refreshHardcoverEnrichmentView(reason)
     Repo.invalidateBookCache(reason or "hardcover")
     pcall(function() require("lib/bookshelf_image_source").invalidateCache() end)
@@ -7326,6 +7520,14 @@ function BookshelfWidget:_openHardcoverMenu(book)
         end),
     }
 
+    local reviews_button = {
+        text = _("Reviews") .. "\xE2\x80\xA6",
+        enabled = link and link.book_id and true or false,
+        callback = closeThen(function()
+            bw:_showHardcoverReviews(book)
+        end),
+    }
+
     local linked_text = link
         and (T(_("Linked: %1"), Hardcover.linkLabel(book.filepath) or tostring(link.book_id)))
         or _("Not linked to Hardcover")
@@ -7335,7 +7537,8 @@ function BookshelfWidget:_openHardcoverMenu(book)
             { { text = linked_text, enabled = false } },
             { embedded_button, select_book_button },
             { select_edition_button, refresh_button },
-            { clear_button, { text = _("Cancel"), callback = function() UIManager:close(dialog) end } },
+            { reviews_button, clear_button },
+            { { text = _("Cancel"), callback = function() UIManager:close(dialog) end } },
         },
     }
     UIManager:show(dialog)

--- a/tests/_test_hardcover.lua
+++ b/tests/_test_hardcover.lua
@@ -4,6 +4,9 @@
 package.path = "./?.lua;./?/init.lua;" .. package.path
 
 local settings = {}
+local hc_settings = {
+    books = {},
+}
 
 package.loaded["lib/bookshelf_settings_store"] = {
     read = function(key, default)
@@ -32,11 +35,60 @@ package.loaded["datastorage"] = {
 }
 
 package.loaded["libs/libkoreader-lfs"] = {
-    attributes = function() return nil end,
+    attributes = function(_path, attr)
+        if attr == "mode" then return "file" end
+        return nil
+    end,
+}
+
+package.loaded["luasettings"] = {
+    open = function(_self, path)
+        assert(path == "/tmp/bookshelf-hardcover-test/hardcoversync_settings.lua",
+            "unexpected settings path: " .. tostring(path))
+        return {
+            readSetting = function(_settings, key) return hc_settings[key] end,
+            saveSetting = function(_settings, key, value) hc_settings[key] = value end,
+            flush = function() end,
+        }
+    end,
 }
 
 package.loaded["hardcover/lib/hardcover_api"] = {
-    query = function(_self, _query, variables)
+    me = function() return { id = 42 } end,
+    query = function(_self, query, variables)
+        if query:find("books_by_pk", 1, true) and variables.id then
+            return {
+                books_by_pk = {
+                    id = variables.id,
+                    title = "Fresh Hardcover Title",
+                    rating = 4.25,
+                    ratings_count = 12,
+                    reviews_count = 2,
+                    user_books = {
+                        {
+                            id = 501,
+                            rating = 4,
+                            review = "<p>Sharp and strange.</p>",
+                            review_has_spoilers = false,
+                            reviewed_at = "2026-05-01T00:00:00",
+                            likes_count = 3,
+                            user = { name = "Reader One", username = "readerone" },
+                        },
+                    },
+                },
+            }
+        end
+        if variables.ids then
+            assert(variables.userId == 42, "expected fetched user id")
+            return {
+                books = {
+                    { id = 123, rating = 4.5, ratings_count = 12,
+                      reviews_count = 2, user_books = { { id = 10, rating = nil } } },
+                    { id = 999, rating = nil, ratings_count = 0,
+                      reviews_count = 0, user_books = { { id = 11, rating = nil } } },
+                },
+            }
+        end
         return {
             book = {
                 id = variables.bookId,
@@ -62,6 +114,12 @@ end
 
 local function reset()
     settings = {}
+    hc_settings = {
+        books = {
+            ["/books/a.epub"] = { book_id = 123, edition_id = 456, title = "Linked A" },
+            ["/books/b.epub"] = { book_id = 999, title = "Linked B" },
+        },
+    }
     Hardcover.invalidate()
 end
 
@@ -139,6 +197,55 @@ test("refreshBookOnline uses KOReader network manager when available", function(
     assert(callback_ok == true, tostring(callback_payload))
     assert(callback_payload.description == "Fresh Hardcover description.", "bad callback payload")
     package.loaded["ui/network/manager"] = nil
+end)
+
+test("refreshRatings fetches linked book ratings and caches them", function()
+    reset()
+    local ok, result = Hardcover.refreshRatings()
+    assert(ok, tostring(result))
+    assert(result.linked == 2, "expected two linked books")
+    assert(result.rated == 1, "expected one rated book")
+    assert(hc_settings.user_id == 42, "expected user id cache")
+    assert(settings.bookshelf_hardcover_ratings["123"].rating == 4.5,
+        "missing cached rating")
+    assert(settings.bookshelf_hardcover_ratings["999"].rating == false,
+        "unrated books should be cached as false")
+end)
+
+test("enrichBook adds cached Hardcover rating and review count", function()
+    reset()
+    settings.bookshelf_hardcover_ratings = {
+        ["123"] = {
+            rating = 4.5,
+            ratings_count = 12,
+            reviews_count = 2,
+        },
+    }
+    Hardcover.invalidate()
+    local book = Hardcover.enrichBook{ filepath = "/books/a.epub" }
+    assert(book.hardcover_book_id == 123, "missing Hardcover book id")
+    assert(book.hardcover_edition_id == 456, "missing Hardcover edition id")
+    assert(book.hardcover_rating == 4.5, "missing Hardcover rating")
+    assert(book.hardcover_reviews_count == 2, "missing reviews count")
+end)
+
+test("fetchReviews loads and caches non-spoiler Hardcover reviews", function()
+    reset()
+    local ok, result = Hardcover.fetchReviews(123)
+    assert(ok, tostring(result))
+    assert(result.title == "Fresh Hardcover Title", "missing review title")
+    assert(result.reviews_count == 2, "missing review count")
+    assert(#result.reviews == 1, "expected one non-spoiler review")
+    assert(result.reviews[1].user_name == "Reader One", "missing reviewer")
+    assert(result.reviews[1].text == "<p>Sharp and strange.</p>", "missing review text")
+
+    local Api = package.loaded["hardcover/lib/hardcover_api"]
+    local old_query = Api.query
+    Api.query = function() error("reviews should come from cache") end
+    local ok_cached, cached = Hardcover.fetchReviews(123)
+    Api.query = old_query
+    assert(ok_cached, tostring(cached))
+    assert(cached.reviews[1].user_name == "Reader One", "cached review missing")
 end)
 
 io.stdout:write(("PASS %d  FAIL %d\n"):format(pass, fail))

--- a/tests/_test_tokens.lua
+++ b/tests/_test_tokens.lua
@@ -71,6 +71,18 @@ test("metadata: literal text passes through", function()
     eq(Tokens.expand("Reading %title by %author.", bookFixture()),
        "Reading Dune by Frank Herbert.")
 end)
+test("metadata: %hardcover_rating formats cached rating", function()
+    local b = bookFixture(); b.hardcover_rating = 4.5
+    eq(Tokens.expand("%hardcover_rating", b), "4.5")
+end)
+test("metadata: %hardcover_stars renders half-star ratings", function()
+    local b = bookFixture(); b.hardcover_rating = 4.5
+    eq(Tokens.expand("%hardcover_stars", b),
+       "\xef\x80\x85\xef\x80\x85\xef\x80\x85\xef\x80\x85\xef\x82\x89")
+end)
+test("metadata: empty Hardcover rating stays empty", function()
+    eq(Tokens.expand("%hardcover_rating|%hardcover_stars", bookFixture()), "|")
+end)
 test("metadata: missing token resolves to empty", function()
     local b = bookFixture(); b.series = nil
     eq(Tokens.expand("%series", b), "")


### PR DESCRIPTION
## Summary

This follows up #100 by adding the cached ratings/reviews pieces of the Hardcover integration.

- Cache public Hardcover ratings, rating counts, and review counts for linked books via an explicit refresh action.
- Optionally show the cached Hardcover rating in the hero rating row instead of the local KOReader rating.
- Make the Hardcover rating row open a non-spoiler review popup, with per-book review fetching cached for 24 hours.
- Add Hardcover rating tokens: `%hardcover_rating` and `%hardcover_stars`.
- Keep normal shelf rendering offline/cache-only; ratings refresh and review fetches go through the same `NetworkMgr:runWhenOnline` wrapper pattern as the enrichment refreshes.

## Notes

I kept this inside the existing Hardcover integration surfaces:

- Settings -> Hardcover enrichment for refresh/toggle/cache clear.
- The hero rating row for rating display and reviews.
- The existing Hardcover long-press submenu gets a Reviews action, but no new top-level long-press item is added.

## Validation

- `luac -p lib/bookshelf_hardcover.lua lib/bookshelf_hero_card.lua lib/bookshelf_widget.lua lib/bookshelf_settings.lua lib/bookshelf_tokens.lua tests/_test_hardcover.lua tests/_test_tokens.lua`
- `git diff --check`
- `tests/run.sh` => 13 suites run, 0 failed, 4 skipped
