### PR TITLE
add zh_CN locale

### DIFF
--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -1,0 +1,1916 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-31 19:26+0100\n"
+"PO-Revision-Date: 2026-06-06 00:24+0800\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
+
+#: _meta.lua:7 main.lua:436
+msgid "Bookshelf"
+msgstr "Bookshelf"
+
+#: _meta.lua:8
+msgid ""
+"A nice-looking home screen for KOReader: pick a book from your shelf and "
+"read it."
+msgstr "一个美观的 KOReader 主屏幕: 从书架上选一本书，开始阅读。"
+
+#: main.lua:226
+msgid ""
+"Bookshelf requires the CoverBrowser plugin. Enable it under Settings > More "
+"plugins."
+msgstr ""
+"Bookshelf 需要 CoverBrowser 插件支持。请在 「设置 > 更多工具> 插件管理」 中启"
+"用它。"
+
+#: main.lua:300 main.lua:304 main.lua:335
+msgid "bookshelf"
+msgstr "bookshelf"
+
+# 已经在KoReader中本地化
+#: main.lua:335
+msgid "Start with: %1"
+msgstr "初始界面: %1"
+
+#: main.lua:440
+msgid "Close Bookshelf"
+msgstr "关闭 Bookshelf"
+
+#: main.lua:440
+msgid "Open Bookshelf"
+msgstr "启用 Bookshelf"
+
+#: main.lua:484
+msgid "Edit book detail view"
+msgstr "编辑图书详情页"
+
+#: main.lua:493
+msgid "Bookshelf chips…"
+msgstr "Bookshelf分类…"
+
+#: main.lua:501
+msgid "Manage collections…"
+msgstr "管理书单…"
+
+#: main.lua:522
+msgid "Settings"
+msgstr "设置"
+
+#: main.lua:533 main.lua:535
+msgid "Selection mode"
+msgstr "多选模式"
+
+#: main.lua:550
+msgid "Updates"
+msgstr "更新"
+
+#: main.lua:555
+msgid "About"
+msgstr "关于"
+
+#: main.lua:699
+msgid "Bookshelf: open or close"
+msgstr "Bookshelf: 打开/关闭"
+
+#: main.lua:705
+msgid "Bookshelf: open"
+msgstr "Bookshelf: 打开"
+
+#: main.lua:708
+msgid "on"
+msgstr "开"
+
+#: main.lua:708
+msgid "off"
+msgstr "关"
+
+#: main.lua:714
+msgid "Bookshelf: next chip"
+msgstr "Bookshelf: 下一个分类"
+
+#: main.lua:720
+msgid "Bookshelf: previous chip"
+msgstr "Bookshelf: 上一个分类"
+
+#: main.lua:726
+msgid "Bookshelf: expand or collapse hero"
+msgstr "Bookshelf: 展开/折叠 头图"
+
+#: main.lua:732
+msgid "Bookshelf: toggle selection mode"
+msgstr "Bookshelf: 切换勾选模式"
+
+#: main.lua:739
+msgid "Bookshelf: toggle selection on focused book"
+msgstr "Bookshelf: 勾选当前书籍"
+
+#: main.lua:745
+msgid "Bookshelf: add focused stack to selection"
+msgstr "Bookshelf: 全选当前分组"
+
+#: main.lua:751
+msgid "Bookshelf: open bulk action menu"
+msgstr "Bookshelf: 打开批量操作菜单"
+
+#: main.lua:834
+msgid "Closing book…"
+msgstr "关闭书籍…"
+
+#: main.lua:1174 lib/bookshelf_settings.lua:2287
+#: lib/bookshelf_settings.lua:2288
+msgid "Development branch"
+msgstr "开发分支"
+
+#: main.lua:1176
+msgid "Branch name (leave empty for stable)"
+msgstr "分支名称 (留空为稳定版本)"
+
+#: main.lua:1179 lib/bookshelf_bulk_actions.lua:164
+#: lib/bookshelf_bulk_actions.lua:379 lib/bookshelf_chip_editor.lua:400
+#: lib/bookshelf_chip_editor.lua:650 lib/bookshelf_chip_editor.lua:1031
+#: lib/bookshelf_chip_editor.lua:1217 lib/bookshelf_collection_manager.lua:333
+#: lib/bookshelf_collection_manager.lua:409
+#: lib/bookshelf_collection_manager.lua:416
+#: lib/bookshelf_collection_manager.lua:441
+#: lib/bookshelf_collection_manager.lua:491
+#: lib/bookshelf_collection_manager.lua:516 lib/bookshelf_color_palette.lua:352
+#: lib/bookshelf_hero_line_editor.lua:421 lib/bookshelf_settings.lua:1073
+#: lib/bookshelf_settings.lua:1248 lib/bookshelf_settings.lua:1583
+#: lib/bookshelf_settings.lua:1730 lib/bookshelf_settings.lua:1794
+#: lib/bookshelf_settings.lua:1857 lib/bookshelf_settings.lua:1921
+#: lib/bookshelf_widget.lua:3365 lib/bookshelf_widget.lua:7570
+#: lib/bookshelf_widget.lua:7777 lib/bookshelf_widget.lua:8284
+#: lib/bookshelf_widget.lua:8702
+msgid "Cancel"
+msgstr "取消"
+
+#: main.lua:1184 lib/bookshelf_chip_editor.lua:675
+#: lib/bookshelf_collection_manager.lua:496
+#: lib/bookshelf_collection_manager.lua:520
+#: lib/bookshelf_hero_line_editor.lua:470
+msgid "Save"
+msgstr "保存"
+
+#: main.lua:1213
+msgid ""
+"Book metadata scanner not available.\n"
+"Install the CoverBrowser plugin to enable it."
+msgstr ""
+"图书元数据扫描器不可用。\n"
+"安装CoverBrowser插件以启用它。"
+
+#: main.lua:1275
+msgid ""
+"This will clear the development branch setting and install the latest stable "
+"release of Bookshelf, then restart KOReader. Continue?"
+msgstr ""
+"这样可以清除开发分支设置，安装最新的Bookshelf稳定版本，之后会重启KOReader。是"
+"否继续？"
+
+#: main.lua:1276 lib/bookshelf_bulk_actions.lua:284
+#: lib/bookshelf_settings.lua:1450 lib/bookshelf_settings.lua:1493
+msgid "Reset"
+msgstr "重置"
+
+#: main.lua:1297
+msgid "Bookshelf update available: v"
+msgstr "Bookshelf 可更新: v"
+
+#: lib/bookshelf_bulk_actions.lua:25
+#, lua-format
+msgid "Edit selected (%d)"
+msgstr "编辑所选 (%d)"
+
+#: lib/bookshelf_bulk_actions.lua:110 lib/bookshelf_widget.lua:7643
+msgid "Unopened"
+msgstr "未读"
+
+#: lib/bookshelf_bulk_actions.lua:111 lib/bookshelf_chip_editor.lua:573
+#: lib/bookshelf_chip_editor.lua:1269 lib/bookshelf_widget.lua:7644
+msgid "Reading"
+msgstr "在读"
+
+#: lib/bookshelf_bulk_actions.lua:112 lib/bookshelf_chip_editor.lua:574
+#: lib/bookshelf_chip_editor.lua:1272 lib/bookshelf_widget.lua:7645
+msgid "On hold"
+msgstr "搁置"
+
+#: lib/bookshelf_bulk_actions.lua:113 lib/bookshelf_chip_editor.lua:575
+#: lib/bookshelf_chip_editor.lua:1273 lib/bookshelf_widget.lua:7646
+msgid "Finished"
+msgstr "读完"
+
+#: lib/bookshelf_bulk_actions.lua:124 lib/bookshelf_bulk_actions.lua:126
+#: lib/bookshelf_chip_editor.lua:210 lib/bookshelf_sort_engine.lua:294
+msgid "Rating"
+msgstr "评分"
+
+#: lib/bookshelf_bulk_actions.lua:126
+msgid "(clear)"
+msgstr "(清除)"
+
+#: lib/bookshelf_bulk_actions.lua:159 lib/bookshelf_widget.lua:7565
+msgid "Clear"
+msgstr "清除"
+
+#: lib/bookshelf_bulk_actions.lua:167 lib/bookshelf_widget.lua:7573
+msgid "Set rating"
+msgstr "设定评分"
+
+#: lib/bookshelf_bulk_actions.lua:183 lib/bookshelf_bulk_actions.lua:185
+#: lib/bookshelf_bulk_actions.lua:187 lib/bookshelf_widget.lua:7349
+msgid "Favourite"
+msgstr "收藏夹"
+
+#: lib/bookshelf_bulk_actions.lua:213 lib/bookshelf_chip_editor.lua:197
+#: lib/bookshelf_chip_editor.lua:1203 lib/bookshelf_widget.lua:7383
+msgid "Collections"
+msgstr "书单"
+
+#: lib/bookshelf_bulk_actions.lua:245 lib/bookshelf_widget.lua:7460
+msgid "Refresh metadata"
+msgstr "刷新元数据"
+
+#: lib/bookshelf_bulk_actions.lua:258 lib/bookshelf_widget.lua:7322
+msgid "Remove from history"
+msgstr "从历史记录删除"
+
+#: lib/bookshelf_bulk_actions.lua:277 lib/bookshelf_widget.lua:7669
+msgid "Reset book data…"
+msgstr "重置书籍数据…"
+
+#: lib/bookshelf_bulk_actions.lua:283
+#, lua-format
+msgid "Reset %d books?"
+msgstr "重置 %d 本书籍？"
+
+#: lib/bookshelf_bulk_actions.lua:314 lib/bookshelf_bulk_actions.lua:366
+#: lib/bookshelf_widget.lua:7677 lib/bookshelf_widget.lua:7738
+msgid "Pending changes discarded"
+msgstr "已撤销未保存更改"
+
+#: lib/bookshelf_bulk_actions.lua:328 lib/bookshelf_bulk_actions.lua:344
+#: lib/bookshelf_chip_editor.lua:627 lib/bookshelf_collection_manager.lua:377
+#: lib/bookshelf_collection_manager.lua:407 lib/bookshelf_widget.lua:7700
+#: lib/bookshelf_widget.lua:7717
+msgid "Delete"
+msgstr "删除"
+
+#: lib/bookshelf_bulk_actions.lua:337
+#, lua-format
+msgid "… and %d more"
+msgstr "…还有 %d 本"
+
+#: lib/bookshelf_bulk_actions.lua:343
+#, lua-format
+msgid "Delete %d books?"
+msgstr "删除 %d 本书籍？"
+
+#: lib/bookshelf_bulk_actions.lua:416 lib/bookshelf_color_palette.lua:356
+#: lib/bookshelf_settings.lua:1076 lib/bookshelf_settings.lua:1251
+#: lib/bookshelf_settings.lua:1615 lib/bookshelf_settings.lua:1797
+#: lib/bookshelf_settings.lua:1860 lib/bookshelf_settings.lua:1924
+#: lib/bookshelf_widget.lua:7781
+msgid "Apply"
+msgstr "应用"
+
+#: lib/bookshelf_bulk_actions.lua:426
+#, lua-format
+msgid "%d files no longer exist; skipped."
+msgstr "%d 个文件不存在；已跳过。"
+
+#: lib/bookshelf_bulk_actions.lua:584
+#, lua-format
+msgid "Applied to %d of %d books · %d failed"
+msgstr "应用 %d / %d本书 · %d 失败"
+
+#: lib/bookshelf_bulk_actions.lua:593
+#, lua-format
+msgid "Apply changes to %d books?"
+msgstr "应用 %d 本书籍的更改？"
+
+#: lib/bookshelf_chip_editor.lua:142 lib/bookshelf_chip_editor.lua:768
+#: lib/bookshelf_settings.lua:2437
+msgid "New chip"
+msgstr "新分类"
+
+#: lib/bookshelf_chip_editor.lua:178 lib/bookshelf_collection_manager.lua:439
+msgid "Name"
+msgstr "名字"
+
+#: lib/bookshelf_chip_editor.lua:179 lib/bookshelf_sort_engine.lua:210
+msgid "Surname"
+msgstr "姓氏"
+
+#: lib/bookshelf_chip_editor.lua:180
+msgid "Most recently read"
+msgstr "最近阅读"
+
+#: lib/bookshelf_chip_editor.lua:181
+msgid "Most recently added"
+msgstr "最近添加"
+
+#: lib/bookshelf_chip_editor.lua:182 lib/bookshelf_sort_engine.lua:286
+msgid "Book count"
+msgstr "书籍数量"
+
+#: lib/bookshelf_chip_editor.lua:190 lib/bookshelf_chip_editor.lua:1183
+msgid "Home (folders)"
+msgstr "首页 (文件夹)"
+
+#: lib/bookshelf_chip_editor.lua:191 lib/bookshelf_chip_editor.lua:1178
+msgid "Home (flattened)"
+msgstr "首页 (平铺)"
+
+#: lib/bookshelf_chip_editor.lua:192 lib/bookshelf_chip_editor.lua:1172
+msgid "Recently read"
+msgstr "最近阅读"
+
+#: lib/bookshelf_chip_editor.lua:193 lib/bookshelf_chip_editor.lua:1173
+msgid "Latest added"
+msgstr "最后添加"
+
+#: lib/bookshelf_chip_editor.lua:194 lib/bookshelf_chip_editor.lua:207
+#: lib/bookshelf_chip_editor.lua:1188 lib/bookshelf_settings.lua:1169
+#: lib/bookshelf_sort_engine.lua:212 lib/bookshelf_tab_model.lua:50
+#: lib/bookshelf_widget.lua:1064
+msgid "Series"
+msgstr "系列"
+
+#: lib/bookshelf_chip_editor.lua:195 lib/bookshelf_chip_editor.lua:1193
+#: lib/bookshelf_settings.lua:77 lib/bookshelf_tab_model.lua:52
+#: lib/bookshelf_widget.lua:1063
+msgid "Authors"
+msgstr "作者"
+
+#: lib/bookshelf_chip_editor.lua:196 lib/bookshelf_chip_editor.lua:1198
+#: lib/bookshelf_tab_model.lua:54 lib/bookshelf_widget.lua:1065
+msgid "Genres"
+msgstr "类型"
+
+#: lib/bookshelf_chip_editor.lua:198 lib/bookshelf_chip_editor.lua:1207
+msgid "Formats"
+msgstr "格式"
+
+#: lib/bookshelf_chip_editor.lua:199 lib/bookshelf_chip_editor.lua:1212
+#: lib/bookshelf_widget.lua:1068
+msgid "Ratings"
+msgstr "评分"
+
+#: lib/bookshelf_chip_editor.lua:200 lib/bookshelf_collection_manager.lua:118
+#: lib/bookshelf_tab_model.lua:58 lib/bookshelf_widget.lua:6803
+#: lib/bookshelf_widget.lua:6836
+msgid "Favourites"
+msgstr "收藏夹"
+
+#: lib/bookshelf_chip_editor.lua:202 lib/bookshelf_widget.lua:1067
+msgid "Folder"
+msgstr "文件夹"
+
+#: lib/bookshelf_chip_editor.lua:203 lib/bookshelf_chip_editor.lua:204
+msgid "Collection"
+msgstr "书单"
+
+#: lib/bookshelf_chip_editor.lua:205
+msgid "Genre"
+msgstr "类型"
+
+#: lib/bookshelf_chip_editor.lua:206 lib/bookshelf_settings.lua:1168
+#: lib/bookshelf_sort_engine.lua:208
+msgid "Author"
+msgstr "作者"
+
+#: lib/bookshelf_chip_editor.lua:208
+msgid "Status"
+msgstr "状态"
+
+#: lib/bookshelf_chip_editor.lua:209
+msgid "Format"
+msgstr "格式"
+
+#: lib/bookshelf_chip_editor.lua:218 lib/bookshelf_chip_editor.lua:1418
+#: lib/bookshelf_settings.lua:1367
+msgid "(none)"
+msgstr "(无)"
+
+#: lib/bookshelf_chip_editor.lua:408
+msgid "Insert icon…"
+msgstr "插入图标…"
+
+#: lib/bookshelf_chip_editor.lua:453
+msgid "OK"
+msgstr "确定"
+
+#: lib/bookshelf_chip_editor.lua:463
+msgid "Chip label"
+msgstr "分类标签"
+
+#: lib/bookshelf_chip_editor.lua:484
+msgid "Sort "
+msgstr "排序"
+
+#: lib/bookshelf_chip_editor.lua:484
+msgid ": (none)"
+msgstr ":  (无)"
+
+#: lib/bookshelf_chip_editor.lua:540
+msgid "Edit label"
+msgstr "编辑标签"
+
+#: lib/bookshelf_chip_editor.lua:558
+msgid "Source: "
+msgstr "数据来源: "
+
+#: lib/bookshelf_chip_editor.lua:569
+msgid "Status: any"
+msgstr "状态: 任何"
+
+#: lib/bookshelf_chip_editor.lua:572 lib/bookshelf_chip_editor.lua:1268
+msgid "Unread"
+msgstr "未读"
+
+#: lib/bookshelf_chip_editor.lua:577 lib/bookshelf_chip_editor.lua:579
+msgid "Status: "
+msgstr "状态: "
+
+#: lib/bookshelf_chip_editor.lua:579
+msgid " selected"
+msgstr " 已选择"
+
+#: lib/bookshelf_chip_editor.lua:626
+msgid "Delete this chip?? This cannot be undone."
+msgstr "删除这个分类？？无法撤销。"
+
+#: lib/bookshelf_chip_editor.lua:803
+msgid "Edit chip"
+msgstr "编辑分类"
+
+#: lib/bookshelf_chip_editor.lua:805
+msgid "Editing: "
+msgstr "编辑: "
+
+#: lib/bookshelf_chip_editor.lua:977 lib/bookshelf_chip_editor.lua:1034
+msgid "Choose "
+msgstr "选择 "
+
+#: lib/bookshelf_chip_editor.lua:978 lib/bookshelf_library_modal.lua:371
+#: lib/bookshelf_widget.lua:3341
+msgid "Search…"
+msgstr "搜索…"
+
+#: lib/bookshelf_chip_editor.lua:1004 lib/bookshelf_chip_editor.lua:1341
+#: lib/bookshelf_chip_editor.lua:1442 lib/bookshelf_collection_manager.lua:539
+#: lib/bookshelf_hero_line_editor.lua:94 lib/bookshelf_settings.lua:232
+#: lib/bookshelf_updater.lua:267 lib/bookshelf_widget.lua:7146
+msgid "Close"
+msgstr "关闭"
+
+#: lib/bookshelf_chip_editor.lua:1088
+msgid "Unrated"
+msgstr "无评分"
+
+#: lib/bookshelf_chip_editor.lua:1174
+msgid "★ Favourites"
+msgstr "★ 收藏"
+
+#: lib/bookshelf_chip_editor.lua:1184
+msgid "Specific folder…"
+msgstr "指定文件夹…"
+
+#: lib/bookshelf_chip_editor.lua:1189
+msgid "Specific series…"
+msgstr "指定系列…"
+
+#: lib/bookshelf_chip_editor.lua:1194
+msgid "Specific author…"
+msgstr "指定作者…"
+
+#: lib/bookshelf_chip_editor.lua:1199
+msgid "Specific genre…"
+msgstr "指定的类型…"
+
+#: lib/bookshelf_chip_editor.lua:1204
+msgid "Specific collection…"
+msgstr "指定书单…"
+
+#: lib/bookshelf_chip_editor.lua:1208
+msgid "Specific format…"
+msgstr "指定格式…"
+
+#: lib/bookshelf_chip_editor.lua:1213
+msgid "Specific rating…"
+msgstr "指定评分…"
+
+#: lib/bookshelf_chip_editor.lua:1220
+msgid "Chip source"
+msgstr "分类来源"
+
+#: lib/bookshelf_chip_editor.lua:1259
+msgid "Any status"
+msgstr "任何状态"
+
+#: lib/bookshelf_chip_editor.lua:1277
+msgid "Done"
+msgstr "完成"
+
+#: lib/bookshelf_chip_editor.lua:1281
+msgid "Reading status filter"
+msgstr "阅读状态筛选"
+
+#: lib/bookshelf_chip_editor.lua:1333
+msgid "Clear sort"
+msgstr "清空规则"
+
+#: lib/bookshelf_chip_editor.lua:1389
+msgid "Sort groups by"
+msgstr "先按…排序分组"
+
+#: lib/bookshelf_chip_editor.lua:1391
+msgid "Within each group, then by"
+msgstr "再按…排序分组"
+
+#: lib/bookshelf_chip_editor.lua:1393
+msgid "Sort by"
+msgstr "先按…排序"
+
+#: lib/bookshelf_chip_editor.lua:1395
+msgid "Then by"
+msgstr "再按…排序"
+
+#: lib/bookshelf_chip_editor.lua:1419
+msgid "Star"
+msgstr "星标"
+
+#: lib/bookshelf_chip_editor.lua:1420
+msgid "Heart"
+msgstr "喜欢"
+
+#: lib/bookshelf_chip_editor.lua:1421
+msgid "Check"
+msgstr "检查"
+
+#: lib/bookshelf_chip_editor.lua:1422
+msgid "Play"
+msgstr "播放"
+
+#: lib/bookshelf_chip_editor.lua:1423 lib/bookshelf_settings.lua:76
+msgid "Book"
+msgstr "书籍"
+
+#: lib/bookshelf_chip_editor.lua:1424 lib/bookshelf_sort_engine.lua:286
+msgid "Books"
+msgstr "书籍(s)"
+
+#: lib/bookshelf_chip_editor.lua:1425 lib/bookshelf_library_modal.lua:407
+#: lib/bookshelf_widget.lua:8707
+msgid "Search"
+msgstr "搜索"
+
+#: lib/bookshelf_chip_editor.lua:1446
+msgid "Chip icon"
+msgstr "分类图标"
+
+#: lib/bookshelf_collection_manager.lua:329
+msgid "Rename collection"
+msgstr "重命名书单"
+
+#: lib/bookshelf_collection_manager.lua:331
+msgid "New name"
+msgstr "新名称"
+
+#: lib/bookshelf_collection_manager.lua:335
+#: lib/bookshelf_collection_manager.lua:403
+msgid "Rename"
+msgstr "重命名"
+
+#: lib/bookshelf_collection_manager.lua:344
+#: lib/bookshelf_collection_manager.lua:450
+msgid "A collection with that name already exists."
+msgstr "已存在同名书单。"
+
+#: lib/bookshelf_collection_manager.lua:375
+msgid "Delete collection \""
+msgstr "删除书单”"
+
+#: lib/bookshelf_collection_manager.lua:376
+msgid "\"? Books are not deleted, only the tag."
+msgstr "\"?书籍不会被删除，仅删除标签。"
+
+#: lib/bookshelf_collection_manager.lua:404
+#: lib/bookshelf_collection_manager.lua:415
+msgid "Pin to chip bar"
+msgstr "固定到分类栏"
+
+#: lib/bookshelf_collection_manager.lua:422
+msgid "Edit collection: "
+msgstr "编辑书单: "
+
+#: lib/bookshelf_collection_manager.lua:438
+#: lib/bookshelf_collection_manager.lua:488
+#: lib/bookshelf_collection_manager.lua:513
+#: lib/bookshelf_collection_manager.lua:538
+msgid "New collection"
+msgstr "新建书单"
+
+#: lib/bookshelf_collection_manager.lua:443
+msgid "Create"
+msgstr "创建"
+
+#: lib/bookshelf_collection_manager.lua:587
+#, lua-format
+msgid "Collections · %d books"
+msgstr "书单 ·%d 本书"
+
+#: lib/bookshelf_collection_manager.lua:599
+msgid ""
+"Tap a collection to cycle through: no change, add to all, remove from all. "
+"Save returns the diff to the bulk menu."
+msgstr ""
+"点击书单可循环切换: 无改动，添加全部，删除全部。保存后变更将同步到批量操作菜"
+"单。"
+
+#: lib/bookshelf_collection_manager.lua:645
+msgid "Manage collections"
+msgstr "管理书单"
+
+#: lib/bookshelf_collection_manager.lua:657
+msgid ""
+"Tap a custom collection to rename, delete, or pin it to the chip bar. Long-"
+"press a book on the shelf and tap Collections… to add or remove it from "
+"collections."
+msgstr ""
+"点击自定义书单可以重命名、删除或固定到分类栏上。长按书架上的一本书，点击「书"
+"单…」来添加/移除书单。"
+
+#: lib/bookshelf_collection_manager.lua:769
+msgid "Add to all"
+msgstr "添加全部"
+
+#: lib/bookshelf_collection_manager.lua:771
+msgid "Remove from all"
+msgstr "删除全部"
+
+#: lib/bookshelf_collection_manager.lua:773
+msgid "Mixed"
+msgstr "混合"
+
+#: lib/bookshelf_collection_manager.lua:786
+msgid "Add"
+msgstr "添加"
+
+#: lib/bookshelf_collection_manager.lua:788
+msgid "Remove"
+msgstr "删除"
+
+#: lib/bookshelf_collection_manager.lua:932
+#, lua-format
+msgid "Page %d of %d"
+msgstr "第 %d / %d 页"
+
+#: lib/bookshelf_color_palette.lua:354 lib/bookshelf_hero_line_editor.lua:89
+#: lib/bookshelf_hero_line_editor.lua:452 lib/bookshelf_settings.lua:791
+#: lib/bookshelf_settings.lua:1074 lib/bookshelf_settings.lua:1249
+#: lib/bookshelf_settings.lua:1593 lib/bookshelf_settings.lua:1795
+#: lib/bookshelf_settings.lua:1858 lib/bookshelf_settings.lua:1922
+msgid "Default"
+msgstr "默认"
+
+#: lib/bookshelf_color_palette.lua:358
+msgid "White"
+msgstr "白色"
+
+#: lib/bookshelf_color_palette.lua:387 lib/bookshelf_color_palette.lua:502
+msgid "Pick a color"
+msgstr "选择一个颜色"
+
+#: lib/bookshelf_color_palette.lua:471
+msgid "Invalid hex color (use #RGB or #RRGGBB)"
+msgstr "无效的十六进制颜色 (使用 #RGB 或 #RRGGBB)"
+
+#: lib/bookshelf_hero_line_editor.lua:51
+msgid "Font size"
+msgstr "字体大小"
+
+#: lib/bookshelf_hero_line_editor.lua:124
+msgid ""
+"Font-family fonts (serif, sans-serif, etc.) only resolve inside the Reader "
+"view. Pick a specific font file instead."
+msgstr ""
+"Font-family字体 (衬线体、无衬线字体等) 只在阅读器视图内解析。选择一个指定的字"
+"体文件。"
+
+#: lib/bookshelf_hero_line_editor.lua:153
+msgid "(Default)"
+msgstr "(默认)"
+
+#: lib/bookshelf_hero_line_editor.lua:159
+msgid "Pick font"
+msgstr "选择字体"
+
+#: lib/bookshelf_hero_line_editor.lua:302
+msgid "Bold"
+msgstr "粗体"
+
+#: lib/bookshelf_hero_line_editor.lua:311
+msgid "Size"
+msgstr "大小"
+
+#: lib/bookshelf_hero_line_editor.lua:322
+msgid "Font ✓"
+msgstr "字体✓"
+
+#: lib/bookshelf_hero_line_editor.lua:322
+msgid "Font…"
+msgstr "字体…"
+
+#: lib/bookshelf_hero_line_editor.lua:372
+msgid "Bar style"
+msgstr "栏样式"
+
+#: lib/bookshelf_hero_line_editor.lua:373
+#, fuzzy
+msgid "Bar: "
+msgstr "Bar: "
+
+#: lib/bookshelf_hero_line_editor.lua:386
+#, fuzzy
+msgid "- Bar"
+msgstr "- Bar"
+
+#: lib/bookshelf_hero_line_editor.lua:386
+#, fuzzy
+msgid "+ Bar"
+msgstr "+ Bar"
+
+#: lib/bookshelf_hero_line_editor.lua:396
+#: lib/bookshelf_hero_line_editor.lua:411
+#, fuzzy
+msgid "Bar height"
+msgstr "Bar高度"
+
+#: lib/bookshelf_hero_line_editor.lua:397
+msgid "Height: "
+msgstr "高度: "
+
+#: lib/bookshelf_hero_line_editor.lua:433
+msgid "Tokens…"
+msgstr "占位符…"
+
+#: lib/bookshelf_hero_line_editor.lua:444
+msgid "Icons…"
+msgstr "图标…"
+
+#: lib/bookshelf_library_modal.lua:856
+msgid "Page %1 of %2"
+msgstr "%1 / %2 页"
+
+#: lib/bookshelf_picker_cell.lua:90
+msgid "book"
+msgstr "书籍"
+
+#: lib/bookshelf_picker_cell.lua:90
+msgid "books"
+msgstr "书籍(s)"
+
+#: lib/bookshelf_settings.lua:75
+msgid "All"
+msgstr "全部"
+
+#: lib/bookshelf_settings.lua:78 lib/bookshelf_sort_engine.lua:240
+msgid "Progress"
+msgstr "进度"
+
+#: lib/bookshelf_settings.lua:79
+msgid "Time"
+msgstr "时间"
+
+#: lib/bookshelf_settings.lua:80
+msgid "Device"
+msgstr "设备"
+
+#: lib/bookshelf_settings.lua:81
+msgid "Logic"
+msgstr "逻辑"
+
+#: lib/bookshelf_settings.lua:129 lib/bookshelf_settings.lua:282
+msgid "Insert token"
+msgstr "插入占位符"
+
+#: lib/bookshelf_settings.lua:130
+msgid "Bookshelf tokens"
+msgstr "Bookshelf 占位符"
+
+#: lib/bookshelf_settings.lua:131
+msgid ""
+"Tokens are placeholders that get replaced with live data when the book "
+"detail view or status line renders.\n"
+"\n"
+"  %title — %book_pct\n"
+"  → Dune — 36%\n"
+"\n"
+"Wrap content in [if:foo]…[/if] to show it only when the token has a value. "
+"Add [else]…[/if] for a fallback.\n"
+"\n"
+"  [if:series]Book %series_num of %series_name[/if]\n"
+"  [if:batt<20]LOW %batt[/if]"
+msgstr ""
+"占位符用于在渲染图书详情页、状态栏时自动替换为实时数据。\n"
+"\n"
+"  %title — %book_pct\n"
+"  → 沙丘 — 36%\n"
+"\n"
+"当内容被[if: foo]…[/if]包围，只在Token有值时显示。添加[else]…[/if]作为备选内"
+"容。\n"
+"\n"
+"  [if:series]Book %series_num of %series_name[/if]\n"
+"  [if:batt<20]LOW %batt[/if]"
+
+#: lib/bookshelf_settings.lua:154
+msgid "Search tokens…"
+msgstr "搜索占位符…"
+
+#: lib/bookshelf_settings.lua:235
+msgid "Help"
+msgstr "帮助"
+
+#: lib/bookshelf_settings.lua:339
+msgid "Rating (interactive)"
+msgstr "评分 (可交互)"
+
+#: lib/bookshelf_settings.lua:340
+msgid "Tags (interactive)"
+msgstr "标签 (可交互)"
+
+#: lib/bookshelf_settings.lua:450
+msgid "Show reading bookmarks"
+msgstr "显示阅读书签"
+
+#: lib/bookshelf_settings.lua:476 lib/bookshelf_settings.lua:1170
+#: lib/bookshelf_shelf_row.lua:202
+msgid "None"
+msgstr "无"
+
+#: lib/bookshelf_settings.lua:477
+msgid "Bookmark style"
+msgstr "书签样式"
+
+#: lib/bookshelf_settings.lua:478
+msgid "Small tick box"
+msgstr "小勾选框"
+
+#: lib/bookshelf_settings.lua:493
+msgid "Completed book badge"
+msgstr "已读完徽章"
+
+#: lib/bookshelf_settings.lua:525
+msgid "Always"
+msgstr "总是"
+
+#: lib/bookshelf_settings.lua:526
+msgid "Within series folder"
+msgstr "在系列文件夹内"
+
+#: lib/bookshelf_settings.lua:527
+msgid "Never"
+msgstr "从不"
+
+#: lib/bookshelf_settings.lua:542
+msgid "Show series #"
+msgstr "显示系列#"
+
+#: lib/bookshelf_settings.lua:578
+msgid "Off"
+msgstr "关闭"
+
+#: lib/bookshelf_settings.lua:579
+msgid "Folders only"
+msgstr "仅限文件夹"
+
+#: lib/bookshelf_settings.lua:580
+msgid "Groups only"
+msgstr "仅限分组"
+
+#: lib/bookshelf_settings.lua:581
+msgid "All stacks"
+msgstr "堆叠所有"
+
+#: lib/bookshelf_settings.lua:596
+msgid "Stack count badge"
+msgstr "堆叠计数徽章"
+
+#: lib/bookshelf_settings.lua:627
+msgid "Total"
+msgstr "总计"
+
+#: lib/bookshelf_settings.lua:628
+msgid "Finished / Total"
+msgstr "完成 / 总计"
+
+#: lib/bookshelf_settings.lua:643
+msgid "Stack count format"
+msgstr "堆叠计数格式"
+
+#: lib/bookshelf_settings.lua:654
+msgid "Show progress bars"
+msgstr "显示进度条"
+
+#: lib/bookshelf_settings.lua:658
+msgid "Show page count"
+msgstr "显示页数"
+
+#: lib/bookshelf_settings.lua:663
+msgid "Show favourites star"
+msgstr "显示收藏星标"
+
+#: lib/bookshelf_settings.lua:709 lib/bookshelf_settings.lua:726
+msgid "default"
+msgstr "默认"
+
+#: lib/bookshelf_settings.lua:805
+msgid "◐ Editing night-mode colors (tap to switch)"
+msgstr "◐ 编辑夜间模式颜色 (点击切换)"
+
+#: lib/bookshelf_settings.lua:807
+msgid "☀ Editing day-mode colors (tap to switch)"
+msgstr "☀ 编辑白天模式颜色 (点击切换)"
+
+#: lib/bookshelf_settings.lua:828
+msgid "Progress bar"
+msgstr "进度条"
+
+#: lib/bookshelf_settings.lua:833
+msgid "Progress bar (% black)"
+msgstr "进度条  (% 黑色)"
+
+#: lib/bookshelf_settings.lua:843
+msgid "Progress bar track"
+msgstr "进度条轨道"
+
+#: lib/bookshelf_settings.lua:848
+msgid "Progress bar track (% black)"
+msgstr "进度条轨道  (% 黑色)"
+
+#: lib/bookshelf_settings.lua:858
+msgid "Bookmark color"
+msgstr "书签颜色"
+
+#: lib/bookshelf_settings.lua:863
+msgid "Bookmark color (% black)"
+msgstr "书签颜色 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:873
+msgid "Finished bookmark color"
+msgstr "已读完书签颜色"
+
+#: lib/bookshelf_settings.lua:879
+msgid "Finished bookmark color (% black)"
+msgstr "已读书签颜色 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:889
+msgid "Favourite star color"
+msgstr "收藏星标颜色"
+
+#: lib/bookshelf_settings.lua:895
+msgid "Favourite star color (% black)"
+msgstr "收藏星标颜色 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:905
+msgid "Badge foreground"
+msgstr "徽章前景"
+
+#: lib/bookshelf_settings.lua:910
+msgid "Badge foreground (% black)"
+msgstr "徽章前景 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:920
+msgid "Badge background"
+msgstr "徽章背景"
+
+#: lib/bookshelf_settings.lua:925
+msgid "Badge background (% black)"
+msgstr "徽章背景 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:935
+msgid "Border color"
+msgstr "边框颜色"
+
+#: lib/bookshelf_settings.lua:937
+msgid ""
+"Color of the book cover frame border + pill badge / page-count badge "
+"borders. Badge foreground is now just badge text. Default black."
+msgstr ""
+"封面边框 + 胶囊徽标 / 页数徽标边框颜色。徽标前景色仅控制徽标文字。默认值为黑"
+"色。"
+
+#: lib/bookshelf_settings.lua:943
+msgid "Border color (% black)"
+msgstr "边框颜色 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:953
+msgid "Folder overlay background"
+msgstr "文件夹叠加背景"
+
+#: lib/bookshelf_settings.lua:958
+msgid "Folder overlay background (% black)"
+msgstr "文件夹叠加背景 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:968
+msgid "Folder text color"
+msgstr "文件夹文本颜色"
+
+#: lib/bookshelf_settings.lua:970
+msgid ""
+"Color of the label text inside folder / series / author / genre / tag cards. "
+"The cardboard outline around the card itself follows the Border color "
+"setting above."
+msgstr ""
+"标签文字颜色在 文件夹/丛书/作者/分类/标签 卡片上。卡片外边框沿用边框颜色配"
+"置。"
+
+#: lib/bookshelf_settings.lua:977
+msgid "Folder text color (% black)"
+msgstr "文件夹文本颜色 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:986
+msgid "Reset to default colors"
+msgstr "重置为默认颜色"
+
+#: lib/bookshelf_settings.lua:1062
+msgid "Badge font scale"
+msgstr "徽章字体比例"
+
+#: lib/bookshelf_settings.lua:1095 lib/bookshelf_settings.lua:1712
+msgid "Edit layout"
+msgstr "编辑布局"
+
+#: lib/bookshelf_settings.lua:1096
+msgid ""
+"Open a small overlay that lets you cycle through bookshelf cover size and "
+"hero size with the bookshelf visible behind it. Changes preview in realtime; "
+"Accept keeps them, Cancel reverts."
+msgstr ""
+"弹出小型悬浮面板，可在书架页面可见状态下循环切换封面尺寸与头图尺寸。修改实时"
+"预览，点击确认保存设置、点击撤销恢复原有参数。"
+
+#: lib/bookshelf_settings.lua:1106
+msgid "Cover display"
+msgstr "封面显示"
+
+#: lib/bookshelf_settings.lua:1112
+msgid "Text size"
+msgstr "字体大小"
+
+#: lib/bookshelf_settings.lua:1118
+msgid "Colors"
+msgstr "颜色"
+
+#: lib/bookshelf_settings.lua:1124
+msgid "Expanded shelf"
+msgstr "展开书架"
+
+#: lib/bookshelf_settings.lua:1130
+msgid "Advanced settings"
+msgstr "高级设置"
+
+#: lib/bookshelf_settings.lua:1167 lib/bookshelf_sort_engine.lua:190
+msgid "Title"
+msgstr "标题"
+
+#: lib/bookshelf_settings.lua:1186
+msgid "Show text below covers"
+msgstr "封面下方显示文本"
+
+#: lib/bookshelf_settings.lua:1237
+msgid "Expanded shelf font scale"
+msgstr "展开书架字体比例"
+
+#: lib/bookshelf_settings.lua:1266
+msgid "Scan all library metadata"
+msgstr "扫描全库元数据"
+
+#: lib/bookshelf_settings.lua:1277 lib/bookshelf_settings.lua:1280
+#: lib/bookshelf_settings.lua:1312
+msgid "Auto"
+msgstr "自动"
+
+#: lib/bookshelf_settings.lua:1278 lib/bookshelf_settings.lua:1313
+msgid "First Last"
+msgstr "名称 姓氏"
+
+#: lib/bookshelf_settings.lua:1279 lib/bookshelf_settings.lua:1314
+msgid "Last, First"
+msgstr "姓氏，名字"
+
+#: lib/bookshelf_settings.lua:1281
+msgid "Author name formatting"
+msgstr "作者姓名格式"
+
+#: lib/bookshelf_settings.lua:1283
+msgid ""
+"How author names are displayed on the Authors chip. Auto keeps whichever "
+"form was first found (\"Richard Osman\" or \"Osman, Richard\"). First Last "
+"and Last, First force every author card into the same shape regardless of "
+"how each book stored the name."
+msgstr ""
+"设置作者卡片的姓名显示格式: 自动模式沿用首次抓取的姓名格式 (如 Richard Osman "
+"或 Osman, Richard)；「名称 姓氏」「姓氏， 名字」会强制统一所有作者排版，不受"
+"书籍原始存储格式影响。"
+
+#: lib/bookshelf_settings.lua:1319
+msgid "\"Latest\" walk depth"
+msgstr "「最新」目录遍历深度"
+
+#: lib/bookshelf_settings.lua:1324
+msgid "Cover cache"
+msgstr "封面缓存"
+
+#: lib/bookshelf_settings.lua:1328
+msgid ""
+"How much memory to use for ready-scaled book covers. A bigger cache keeps "
+"more covers warm -- smoother paging and preloading -- at the cost of RAM. "
+"Default 24 MB. Lower it if memory is tight; raise it on a device with plenty "
+"of RAM. (How many covers that holds depends on their size: roughly 200-400 "
+"small grayscale covers, fewer large or colour ones.)"
+msgstr ""
+"用于缓存已缩放书籍封面的内存配额。缓存容量越大，留存的预热封面越多，翻页与预"
+"加载会更流畅，但会占用更多运行内存；默认 24 兆字节。设备内存紧张时可调低数"
+"值，内存充裕则适当调高。 (可缓存封面数量受单张大小影响: 小型灰度封面约可存 "
+"200～400 张，大图或彩色封面存量更少。)"
+
+#: lib/bookshelf_settings.lua:1340
+msgid "Clear cover cache"
+msgstr "清除封面缓存"
+
+#: lib/bookshelf_settings.lua:1341
+msgid ""
+"Drop all cached scaled covers from memory. Use this when a book's cover has "
+"been updated outside KOReader (e.g. a metadata-enrichment tool rewrote the "
+"EPUB) and the old cover is still showing on the shelf. The next render "
+"fetches fresh covers from the EPUBs. Restarting KOReader has the same effect."
+msgstr ""
+"清空内存中所有已缩放封面缓存。若在程序外部修改了书籍封面 (例如用元数据工具重"
+"写 EPUB 文件)，书架仍显示旧封面时可使用本功能；下次加载会从 EPUB 重新读取最新"
+"封面，重启 KOReader 效果一致。"
+
+#: lib/bookshelf_settings.lua:1352
+msgid "Cover cache cleared"
+msgstr "封面缓存已清除"
+
+#: lib/bookshelf_settings.lua:1367
+msgid "Image library"
+msgstr "图片库"
+
+#: lib/bookshelf_settings.lua:1370
+msgid ""
+"Where Bookshelf looks for custom cover images. For stacks, place files like "
+"authors/author-name.jpg into the matching subfolder (authors, series, "
+"genres, collections). For folders, drop a cover.jpg into the folder itself. "
+"See the README for more matching options."
+msgstr ""
+"设置书架自定义封面图片的查找目录。合集封面需将图片 (如 authors / 作者名.jpg)"
+"放入对应子目录 (作者、丛书、分类、合集文件夹)；文件夹封面直接在目录内放入 "
+"cover.jpg 即可，更多匹配规则参阅说明文档。"
+
+#: lib/bookshelf_settings.lua:1376
+msgid "Double tap to open books"
+msgstr "通过双击打开书籍"
+
+#: lib/bookshelf_settings.lua:1377
+msgid ""
+"When enabled, opening a book from the hero card or from a shelf cover in "
+"expanded mode requires two taps -- the first selects the cover (focus ring), "
+"the second commits. Useful if you tend to open books accidentally while "
+"browsing. Regular shelf covers (with the hero visible) already work this way "
+"-- tap stages the book as the hero preview, tap the hero opens it -- and are "
+"unaffected by this setting."
+msgstr ""
+"开启后，在头图卡片或展开模式的书架封面处打开书籍需要双击操作：首次点击选中封"
+"面 (出现选中高亮框)，再次点击才启动书本。适合浏览时容易误点开图书的用户。常规"
+"书架封面 (显示头部大图) 本身已是该交互逻辑：单击将图书设为头图预览，点击头图"
+"打开书籍，不受本选项控制。"
+
+#: lib/bookshelf_settings.lua:1401
+msgid "Closing book notification"
+msgstr "退出书籍提醒"
+
+#: lib/bookshelf_settings.lua:1402
+msgid ""
+"Show a 'Closing book…' message in the centre of the screen while a book is "
+"being closed back to Bookshelf. The book-close work takes a moment, so the "
+"message confirms your gesture landed during the wait. Some users on color e-"
+"ink panels see a brief flash from the message appearing. Turn it off here if "
+"you prefer no message and no flash."
+msgstr ""
+"退回书架关闭书籍时，屏幕正中显示「正在关闭书本…」提示。关闭进程需要短暂耗时，"
+"该提示用于反馈操作已生效。部分彩色墨水屏设备会因弹窗闪现短暂屏闪，如需消除提"
+"示与闪屏可在此关闭。"
+
+#: lib/bookshelf_settings.lua:1422
+msgid "Follow KOReader"
+msgstr "跟随 KOReader 设置"
+
+#: lib/bookshelf_settings.lua:1424
+msgid "Bookshelf UI font: %1"
+msgstr "Bookshelf 界面字体: %1"
+
+#: lib/bookshelf_settings.lua:1426
+msgid ""
+"The font Bookshelf uses for its own UI text (chips, labels, metadata). Pick "
+"any installed font (same picker as the hero card); '(Default)' follows your "
+"KOReader UI font. The hero title and author have their own fonts in the hero "
+"card editor."
+msgstr ""
+"书架界面文字 (分类、标签、元数据)所用字体，可任选已安装字体 (选择器与头图卡片"
+"相同)；'(默认)' 选项同步 KOReader 全局界面字体。头图的书名、作者字体需在头图"
+"卡片编辑面板单独设置。"
+
+#: lib/bookshelf_settings.lua:1434
+msgid "Reset chip bar to defaults"
+msgstr "将分类栏重置为默认值"
+
+#: lib/bookshelf_settings.lua:1435
+msgid ""
+"Clears your custom chip layout (which chips are shown, their order, their "
+"labels and icons, their sources and filters and sorts) and restores the "
+"fresh-install chip set: Home / Recent / Series / Favourites enabled, the "
+"rest available to toggle on. Also returns the active chip to Home and the "
+"page indicator to 1. Other settings (hero text, fonts, colors) are "
+"unaffected."
+msgstr ""
+"清空自定义标签布局 (包含标签显示项、排序顺序、名称图标、来源、筛选及排序规"
+"则)，恢复软件初始默认标签配置: 首页、最新入库、丛书、收藏设为启用状态，其余标"
+"签可手动开启。同时将当前选中标签切回首页、页码重置为 1。头图文字、字体、配色"
+"等其他设置保持不变。"
+
+#: lib/bookshelf_settings.lua:1446
+msgid ""
+"Reset the chip bar to default settings?\n"
+"\n"
+"All custom chips you have created or edited will be lost. Other Bookshelf "
+"settings (hero text, fonts, colors) are unaffected."
+msgstr ""
+"是否将分类栏恢复默认设置？\n"
+"\n"
+"所有自行新增、修改的自定义分类将会被清除；书架其余配置 (头图文字、字体、配色)"
+"保持不变。"
+
+#: lib/bookshelf_settings.lua:1482
+msgid "Reset book detail area to defaults"
+msgstr "重置书籍详情区域为默认值"
+
+#: lib/bookshelf_settings.lua:1483
+msgid ""
+"Clears your hero/book-detail customizations and restores the fresh-install "
+"detail layout, including the bundled title (Inter ExtraBold) and author "
+"(Caveat) fonts. The Bookshelf UI font and chip bar are unaffected."
+msgstr ""
+"清除头图与书籍详情页的自定义样式，恢复出厂默认排版，标题字体 (Inter "
+"ExtraBold)、作者字体 (Caveat)一并还原为预设样式。书架界面字体、顶部贴片栏配置"
+"不受改动。"
+
+#: lib/bookshelf_settings.lua:1490
+msgid ""
+"Reset the book detail area to default settings?\n"
+"\n"
+"All hero/detail text and font customizations will be lost. The Bookshelf UI "
+"font and chip bar are unaffected."
+msgstr ""
+"是否重置书籍详情区域为默认配置？\n"
+"\n"
+"所有头图与详情页的文字、字体自定义设置将会清空；书架界面字体、顶部贴片栏保持"
+"不变。"
+
+#: lib/bookshelf_settings.lua:1508
+msgid "BETA: Read calibre metadata.calibre"
+msgstr "BETA: 读取 caliber 的 metadata.calibre"
+
+#: lib/bookshelf_settings.lua:1509
+msgid ""
+"For users with a Calibre-managed library. Reads the metadata.calibre JSON "
+"file at home_dir to cover title / authors / series / tags / language for "
+"every book in the library — no per-book extraction needed. BIM-cached "
+"metadata still wins per field; Calibre data only fills gaps."
+msgstr ""
+"面向使用 Calibre 管理书库的用户: 读取主目录下的 metadata.calibre 配置文件，批"
+"量补全全库书籍的书名、作者、丛书、标签、语种信息，无需逐本解析电子书提取元数"
+"据。各字段优先采用 BIM 缓存数据，Calibre 数据仅用来填补空缺内容。"
+
+#: lib/bookshelf_settings.lua:1655
+msgid "Regular"
+msgstr "常规"
+
+#: lib/bookshelf_settings.lua:1655 lib/bookshelf_settings.lua:1656
+msgid "Large"
+msgstr "大"
+
+#: lib/bookshelf_settings.lua:1656
+msgid "Small"
+msgstr "小"
+
+#: lib/bookshelf_settings.lua:1656
+msgid "Medium"
+msgstr "中"
+
+#: lib/bookshelf_settings.lua:1718
+msgid "Book: "
+msgstr "书籍:  "
+
+#: lib/bookshelf_settings.lua:1725
+msgid "Bookshelf: "
+msgstr "书架: "
+
+#: lib/bookshelf_settings.lua:1731
+msgid "Accept"
+msgstr "接受"
+
+#: lib/bookshelf_settings.lua:1783
+msgid "Book detail font scale"
+msgstr "书籍详情字体比例"
+
+#: lib/bookshelf_settings.lua:1846
+msgid "Chip bar font scale"
+msgstr "分类栏字体比例"
+
+#: lib/bookshelf_settings.lua:1910
+msgid "Stack & folder label scale"
+msgstr "堆叠 &文件夹 标签比例"
+
+#: lib/bookshelf_settings.lua:1978
+msgid "Hero card"
+msgstr "头图卡片"
+
+#: lib/bookshelf_settings.lua:1979
+msgid "Chip bar"
+msgstr "分类栏"
+
+#: lib/bookshelf_settings.lua:1980
+msgid "Stack & folder labels"
+msgstr "堆叠 &文件夹 标签"
+
+#: lib/bookshelf_settings.lua:1981
+msgid "Expanded shelf labels"
+msgstr "扩展书架标签"
+
+#: lib/bookshelf_settings.lua:1982
+msgid "Cover badges"
+msgstr "封面徽章"
+
+#: lib/bookshelf_settings.lua:1999
+msgid "Choose image library folder"
+msgstr "选择图片库文件夹"
+
+#: lib/bookshelf_settings.lua:2025
+msgid "\"Latest\" folder walk depth"
+msgstr "「最新」文件夹遍历深度"
+
+#: lib/bookshelf_settings.lua:2026
+msgid ""
+"How deep to scan your library folder for newly-added books. Higher values "
+"take longer on a cold start."
+msgstr ""
+"设置检索新书时，书库目录的递归扫描层级。层级数值越大，首次启动全库检索耗时越"
+"长。"
+
+#: lib/bookshelf_settings.lua:2042
+msgid "MB"
+msgstr "MB"
+
+#: lib/bookshelf_settings.lua:2043
+msgid "Cover cache budget"
+msgstr "封面缓存配额"
+
+#: lib/bookshelf_settings.lua:2044
+msgid ""
+"Memory budget for ready-scaled book covers (MB). Higher = smoother paging "
+"and preloading, more RAM. Default 24 MB."
+msgstr ""
+"预缩放封面内存配额 (MB): 数值越高，翻页与预加载越流畅，占用运行内存越多，默"
+"认 24MB。"
+
+#: lib/bookshelf_settings.lua:2178
+msgid "Link copied to clipboard"
+msgstr "链接已复制到剪贴板"
+
+#: lib/bookshelf_settings.lua:2254
+msgid "Notify on wake when update available"
+msgstr "通知可用更新"
+
+#: lib/bookshelf_settings.lua:2273
+msgid "Update available"
+msgstr "更新可用"
+
+#: lib/bookshelf_settings.lua:2276
+msgid "Installed version"
+msgstr "已安装的版本"
+
+#: lib/bookshelf_settings.lua:2282
+msgid "Developer updates"
+msgstr "开发版更新"
+
+#: lib/bookshelf_settings.lua:2298
+msgid "Check for updates"
+msgstr "检查更新"
+
+#: lib/bookshelf_settings.lua:2299
+msgid "Install branch"
+msgstr "安装分支版本"
+
+#: lib/bookshelf_settings.lua:2305
+msgid "Reset to latest stable release"
+msgstr "重置到最新稳定版本"
+
+#: lib/bookshelf_settings.lua:2316 lib/bookshelf_settings.lua:2319
+msgid "Installed: v"
+msgstr "安装: v"
+
+#: lib/bookshelf_settings.lua:2359
+msgid "Flexible chip widths"
+msgstr "自适应分类宽度"
+
+#: lib/bookshelf_settings.lua:2360
+msgid ""
+"Off: every chip gets the same width. On: each chip is sized to its label, so "
+"single-icon chips stay narrow and longer text labels get more room. Falls "
+"back to equal widths when natural sizes don't fit."
+msgstr ""
+"关闭: 所有分类按钮宽度统一固定。开启: 各分类按文字内容自适应尺寸，仅图标无文"
+"字的分类保持窄幅，文字较长的分类自动拓宽。若自适应后整体超出栏宽，自动变回等"
+"宽布局。"
+
+#: lib/bookshelf_settings.lua:2420
+msgid "+ Add new chip"
+msgstr "+ 添加新分类"
+
+#: lib/bookshelf_sort_engine.lua:203
+msgid "Filename"
+msgstr "文件名"
+
+#: lib/bookshelf_sort_engine.lua:208
+msgid "Author (given name)"
+msgstr "作者 (名字)"
+
+#: lib/bookshelf_sort_engine.lua:210
+msgid "Author surname"
+msgstr "作者姓氏"
+
+#: lib/bookshelf_sort_engine.lua:212
+msgid "Series name"
+msgstr "系列名称"
+
+#: lib/bookshelf_sort_engine.lua:215
+msgid "Series index"
+msgstr "系列编号"
+
+#: lib/bookshelf_sort_engine.lua:215
+msgid "Series #"
+msgstr "系列#"
+
+#: lib/bookshelf_sort_engine.lua:223
+msgid "Series + index"
+msgstr "系列+编号"
+
+#: lib/bookshelf_sort_engine.lua:223
+msgid "Series + #"
+msgstr "系列 +#"
+
+#: lib/bookshelf_sort_engine.lua:234
+msgid "Last opened"
+msgstr "最近打开"
+
+#: lib/bookshelf_sort_engine.lua:234
+msgid "Opened"
+msgstr "已打开"
+
+#: lib/bookshelf_sort_engine.lua:240
+msgid "Percent read"
+msgstr "阅读进度"
+
+#: lib/bookshelf_sort_engine.lua:245
+msgid "Unread/Reading/Finished"
+msgstr "未读/在读/读完"
+
+#: lib/bookshelf_sort_engine.lua:246
+msgid "Unread 1st"
+msgstr "未读优先"
+
+#: lib/bookshelf_sort_engine.lua:255
+msgid "Reading/Unread/Finished"
+msgstr "在读/未读/已读"
+
+#: lib/bookshelf_sort_engine.lua:256
+msgid "Reading 1st"
+msgstr "在读优先"
+
+#: lib/bookshelf_sort_engine.lua:267
+msgid "Date added"
+msgstr "添加日期"
+
+#: lib/bookshelf_sort_engine.lua:267 lib/bookshelf_widget.lua:6476
+msgid "Added"
+msgstr "已添加"
+
+#: lib/bookshelf_sort_engine.lua:279
+msgid "File size"
+msgstr "文件大小"
+
+#: lib/bookshelf_sort_engine.lua:301
+msgid "Page count"
+msgstr "总页数"
+
+#: lib/bookshelf_sort_engine.lua:301
+msgid "Pages"
+msgstr "页数"
+
+#: lib/bookshelf_tab_model.lua:44
+msgid "Home"
+msgstr "首页"
+
+#: lib/bookshelf_tab_model.lua:46
+msgid "Recent"
+msgstr "最近阅读"
+
+#: lib/bookshelf_tab_model.lua:48
+msgid "Latest"
+msgstr "最新入库"
+
+#: lib/bookshelf_tab_model.lua:56 lib/bookshelf_widget.lua:1066
+msgid "Tags"
+msgstr "标签"
+
+#: lib/bookshelf_updater.lua:106
+msgid "Open the releases page in a browser?"
+msgstr "在浏览器里打开发布页面？"
+
+#: lib/bookshelf_updater.lua:107
+msgid "Open"
+msgstr "打开"
+
+#: lib/bookshelf_updater.lua:189
+msgid "Checking for updates..."
+msgstr "正在检查更新…"
+
+#: lib/bookshelf_updater.lua:201
+msgid "Could not check for updates."
+msgstr "无法查看更新。"
+
+#: lib/bookshelf_updater.lua:238
+msgid "Bookshelf is up to date."
+msgstr "Bookshelf 已是最新版本。"
+
+#: lib/bookshelf_updater.lua:239
+msgid "Version: "
+msgstr "版本: "
+
+#: lib/bookshelf_updater.lua:273
+msgid "Update and restart"
+msgstr "更新并重启"
+
+#: lib/bookshelf_updater.lua:278
+msgid "No download available for this release."
+msgstr "当前发布版本暂无可用下载。"
+
+#: lib/bookshelf_updater.lua:289
+msgid "Update available!"
+msgstr "更新可用！"
+
+#: lib/bookshelf_updater.lua:290
+msgid "Installed: "
+msgstr "已安装: "
+
+#: lib/bookshelf_updater.lua:291
+msgid "Latest: "
+msgstr "最新版: "
+
+#: lib/bookshelf_updater.lua:307
+msgid "Downloading update..."
+msgstr "正在下载更新......"
+
+#: lib/bookshelf_updater.lua:369
+msgid "Download failed."
+msgstr "下载失败。"
+
+#: lib/bookshelf_updater.lua:381
+msgid "Installation failed: "
+msgstr "安装失败: "
+
+#: lib/bookshelf_updater.lua:398
+msgid "Bookshelf updated to v"
+msgstr "Bookshelf更新到 v"
+
+#: lib/bookshelf_updater.lua:399
+msgid "Restart KOReader now?"
+msgstr "现在重启KOReader？"
+
+#: lib/bookshelf_updater.lua:400
+msgid "Restart"
+msgstr "重新启动"
+
+#: lib/bookshelf_updater.lua:418
+msgid "Could not install branch:"
+msgstr "无法安装分支版本:"
+
+#: lib/bookshelf_updater.lua:433
+msgid "Downloading latest release..."
+msgstr "正在下载最新的发布版本..."
+
+#: lib/bookshelf_updater.lua:444
+msgid "Could not fetch latest release."
+msgstr "无法获取最新版本。"
+
+#: lib/bookshelf_updater.lua:457
+msgid "Latest release has no downloadable zip."
+msgstr "最新发布版本没有可下载的压缩包。"
+
+#: lib/bookshelf_widget.lua:1274
+#, lua-format
+msgid "No matches for \"%s\""
+msgstr "无法匹配 「%s」"
+
+#: lib/bookshelf_widget.lua:1276
+msgid ""
+"Nothing in Series yet · Add series metadata to your books and they will "
+"appear here"
+msgstr "尚无「系列」分类 · 将系列元数据添加到你的书籍中，它们就会显示在这里"
+
+#: lib/bookshelf_widget.lua:1278
+msgid ""
+"No authors yet · Add author metadata to your books and they will appear here"
+msgstr "尚无「作者」分类 · 将作者元数据添加到你的书籍中，它们就会显示在这里"
+
+#: lib/bookshelf_widget.lua:1280
+msgid ""
+"No genres yet · Add keywords or subject metadata to your books and they will "
+"appear here"
+msgstr "尚无「题材」分类 · 将题材元数据添加到你的书籍中，它们就会显示在这里"
+
+#: lib/bookshelf_widget.lua:1282
+msgid ""
+"No collections yet · Long-press a book and tap 'Collections…' to create one"
+msgstr "尚无「书单」分类 · 长按一本书，点击「书单…」创造一个"
+
+#: lib/bookshelf_widget.lua:1284
+msgid "No favourites yet · Long-press a book and tap 'Add to favourites'"
+msgstr "尚无「收藏」分类 · 长按一本书，点击「收藏…」"
+
+#: lib/bookshelf_widget.lua:1286
+msgid "No books found · Set your library folder in Settings then tap Latest"
+msgstr "未检索到书籍 · 前往设置配置书库文件夹后，点击「新近入库」"
+
+#: lib/bookshelf_widget.lua:1288
+msgid "No recent reads yet · Open a book and it will appear here"
+msgstr "尚无在读 · 打开一本书，它会出现在这里"
+
+#: lib/bookshelf_widget.lua:1294
+msgid ""
+"No books here yet · Pick a folder to use as your KOReader library and books "
+"in it will appear here."
+msgstr ""
+"这里还没有书 · 选择一个文件夹作为你的KOReader书库，里面的书籍会显示在这里。"
+
+#: lib/bookshelf_widget.lua:1304
+#, lua-format
+msgid "No books in %s yet · Long-press the chip to edit its source or filter"
+msgstr "尚无书籍在「%s」 · 长按分类以编辑其来源或过滤"
+
+#: lib/bookshelf_widget.lua:1307
+#, lua-format
+msgid "No books in %s yet"
+msgstr "尚无书籍在「%s」"
+
+#: lib/bookshelf_widget.lua:1319
+#, lua-format
+msgid "Nothing in %s yet · Long-press the chip to edit its filter"
+msgstr "「%s」里什么也没有 · 长按分类以编辑其过滤"
+
+#: lib/bookshelf_widget.lua:1403
+msgid "Set home folder"
+msgstr "设置主页文件夹"
+
+#: lib/bookshelf_widget.lua:1412
+msgid "Current home folder:"
+msgstr "当前主页文件夹:"
+
+#: lib/bookshelf_widget.lua:2476 lib/bookshelf_widget.lua:7298
+msgid "File no longer exists. The bookshelf entry is stale."
+msgstr "文件已不存在，Bookshelf 条目失效。"
+
+#: lib/bookshelf_widget.lua:3149 lib/bookshelf_widget.lua:4845
+msgid "Selection cleared"
+msgstr "已取消选中"
+
+#: lib/bookshelf_widget.lua:3315
+#, lua-format
+msgid "No items start with %q"
+msgstr "没有以 %q 开头的项目"
+
+#: lib/bookshelf_widget.lua:3331
+msgid "Enter text, letter or page number"
+msgstr "输入文本、字母或页码"
+
+#: lib/bookshelf_widget.lua:3333
+#, lua-format
+msgid "(a - z) or (1 - %d)"
+msgstr "(a - z) 或 (1 - %d)"
+
+#: lib/bookshelf_widget.lua:3349
+msgid "Go to letter"
+msgstr "跳转到首字母"
+
+#: lib/bookshelf_widget.lua:3370
+msgid "Go to page"
+msgstr "跳转页码"
+
+#: lib/bookshelf_widget.lua:3376
+#, lua-format
+msgid "Page must be between 1 and %d"
+msgstr "页码需在 1～%d 区间内"
+
+#: lib/bookshelf_widget.lua:6225
+msgid "Refreshing library…"
+msgstr "正在刷新书库…"
+
+#: lib/bookshelf_widget.lua:6277
+msgid "✓ Bookshelf is my home screen"
+msgstr "✓ Bookshelf 设为主屏幕"
+
+#: lib/bookshelf_widget.lua:6278
+msgid "Set as home screen"
+msgstr "设置为主屏幕"
+
+#: lib/bookshelf_widget.lua:6285 lib/bookshelf_widget.lua:6289
+msgid "Bookshelf will load on next launch"
+msgstr "Bookshelf 将在下次启动时加载"
+
+#: lib/bookshelf_widget.lua:6422
+msgid "(no title)"
+msgstr "(无标题)"
+
+#: lib/bookshelf_widget.lua:6478
+msgid "Read"
+msgstr "已读"
+
+#: lib/bookshelf_widget.lua:7139
+msgid "Description"
+msgstr "描述"
+
+#: lib/bookshelf_widget.lua:7477
+msgid "Metadata refresh queued"
+msgstr "元数据刷新队列"
+
+#: lib/bookshelf_widget.lua:7716
+msgid "Delete file permanently?"
+msgstr "永久删除文件？"
+
+#: lib/bookshelf_widget.lua:7729
+msgid "Failed to delete file."
+msgstr "删除文件失败。"
+
+#: lib/bookshelf_widget.lua:7761
+msgid "Select"
+msgstr "选择"
+
+#: lib/bookshelf_widget.lua:7793
+msgid "File no longer exists."
+msgstr "文件已不存在。"
+
+#: lib/bookshelf_widget.lua:8171
+msgid "this folder"
+msgstr "这个文件夹"
+
+#: lib/bookshelf_widget.lua:8172
+msgid "this series"
+msgstr "这个系列"
+
+#: lib/bookshelf_widget.lua:8173
+msgid "this author"
+msgstr "这个作者"
+
+#: lib/bookshelf_widget.lua:8174
+msgid "this genre"
+msgstr "这个题材"
+
+#: lib/bookshelf_widget.lua:8175
+msgid "this collection"
+msgstr "这个书单"
+
+#: lib/bookshelf_widget.lua:8176
+msgid "this format"
+msgstr "这个格式"
+
+#: lib/bookshelf_widget.lua:8177
+msgid "this rating"
+msgstr "这个评分"
+
+#: lib/bookshelf_widget.lua:8178
+msgid "this group"
+msgstr "这个分组"
+
+#: lib/bookshelf_widget.lua:8200
+#, lua-format
+msgid ""
+"Pin %s to the chip bar for quick access,\n"
+"or remove its %d books from your selection."
+msgstr ""
+"将「%s」固定到分类栏上以便快速访问，\n"
+"或者将 %d 本书从你的选择中移除。"
+
+#: lib/bookshelf_widget.lua:8206
+#, lua-format
+msgid ""
+"Pin %s to the chip bar for quick access,\n"
+"or add %d more / remove the %d already selected."
+msgstr ""
+"将「%s」固定到分类栏上以便快速访问，\n"
+"或者可再新增 %d 个 / 移除已选中的 %d 个。"
+
+#: lib/bookshelf_widget.lua:8210
+#, lua-format
+msgid ""
+"Pin %s to the chip bar for quick access,\n"
+"or add its %d books to a selection for bulk edits."
+msgstr ""
+"将「%s」固定到分类栏上以便快速访问，\n"
+"或将其下 %d 本图书加入选中列表以批量编辑。"
+
+#: lib/bookshelf_widget.lua:8285
+msgid "Pin"
+msgstr "固定"
+
+#: lib/bookshelf_widget.lua:8300 lib/bookshelf_widget.lua:8301
+#, lua-format
+msgid "Add %d"
+msgstr "添加 %d 个"
+
+#: lib/bookshelf_widget.lua:8310
+#, lua-format
+msgid "Remove %d"
+msgstr "删除 %d 个"
+
+#: lib/bookshelf_widget.lua:8330
+msgid "Set folder image…"
+msgstr "设置文件夹图片…"
+
+#: lib/bookshelf_widget.lua:8337
+msgid "Clear folder image"
+msgstr "清除文件夹图片"
+
+#: lib/bookshelf_widget.lua:8357 lib/bookshelf_widget.lua:8368
+msgid "Set author image…"
+msgstr "设置作者图片…"
+
+#: lib/bookshelf_widget.lua:8358 lib/bookshelf_widget.lua:8369
+msgid "Set series image…"
+msgstr "设置系列图片…"
+
+#: lib/bookshelf_widget.lua:8359 lib/bookshelf_widget.lua:8370
+msgid "Set genre image…"
+msgstr "设定题材图片…"
+
+#: lib/bookshelf_widget.lua:8360 lib/bookshelf_widget.lua:8371
+msgid "Set collection image…"
+msgstr "设置书单图片…"
+
+#: lib/bookshelf_widget.lua:8361 lib/bookshelf_widget.lua:8374
+msgid "Clear author image"
+msgstr "清除作者图片"
+
+#: lib/bookshelf_widget.lua:8362 lib/bookshelf_widget.lua:8375
+msgid "Clear series image"
+msgstr "清除系列图片"
+
+#: lib/bookshelf_widget.lua:8363 lib/bookshelf_widget.lua:8376
+msgid "Clear genre image"
+msgstr "清除题材图片"
+
+#: lib/bookshelf_widget.lua:8364 lib/bookshelf_widget.lua:8377
+msgid "Clear collection image"
+msgstr "清除书单图片"
+
+#: lib/bookshelf_widget.lua:8445
+msgid "Choose folder image"
+msgstr "选择文件夹图片"
+
+#: lib/bookshelf_widget.lua:8484
+msgid "Choose image"
+msgstr "选择图像"
+
+#: lib/bookshelf_widget.lua:8696
+msgid "Search library"
+msgstr "搜索库"
+
+#: lib/bookshelf_widget.lua:8698
+msgid "title, author, series, genre…"
+msgstr "标题，作者，系列，题材…"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-31 19:26+0100\n"
-"PO-Revision-Date: 2026-06-06 01:40+0800\n"
+"POT-Creation-Date: 2026-06-07 06:31+0100\n"
+"PO-Revision-Date: 2026-06-08 04:50+0800\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: zh_CN\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-#: _meta.lua:7 main.lua:436
+#: _meta.lua:7 main.lua:453
 msgid "Bookshelf"
 msgstr "Bookshelf"
 
@@ -28,7 +28,7 @@ msgid ""
 "read it."
 msgstr "一个美观的 KOReader 主屏幕: 从书架上选一本书，开始阅读。"
 
-#: main.lua:226
+#: main.lua:242
 msgid ""
 "Bookshelf requires the CoverBrowser plugin. Enable it under Settings > More "
 "plugins."
@@ -36,109 +36,112 @@ msgstr ""
 "Bookshelf 需要 CoverBrowser 插件支持。请在 「设置 > 更多工具> 插件管理」 中启"
 "用它。"
 
-#: main.lua:300 main.lua:304 main.lua:335
+#: main.lua:316 main.lua:320 main.lua:351
 msgid "bookshelf"
 msgstr "bookshelf"
 
-# 已经在KoReader中本地化
-#: main.lua:335
+#: main.lua:351
 msgid "Start with: %1"
 msgstr "初始界面: %1"
 
-#: main.lua:440
+#: main.lua:457
 msgid "Close Bookshelf"
 msgstr "关闭 Bookshelf"
 
-#: main.lua:440
+#: main.lua:457
 msgid "Open Bookshelf"
 msgstr "开启 Bookshelf"
 
-#: main.lua:484
+#: main.lua:501
 msgid "Edit book detail view"
 msgstr "编辑图书详情"
 
-#: main.lua:493
+#: main.lua:510
 msgid "Bookshelf chips…"
 msgstr "书架分类…"
 
-#: main.lua:501
+#: main.lua:518
 msgid "Manage collections…"
 msgstr "管理书单…"
 
-#: main.lua:522
+#: main.lua:548
+msgid "Hardcover enrichment"
+msgstr "Hardcover 内容补充"
+
+#: main.lua:558
 msgid "Settings"
 msgstr "设置"
 
-#: main.lua:533 main.lua:535
+#: main.lua:569 main.lua:571
 msgid "Selection mode"
 msgstr "多选模式"
 
-#: main.lua:550
+#: main.lua:586
 msgid "Updates"
 msgstr "更新"
 
-#: main.lua:555
+#: main.lua:591
 msgid "About"
 msgstr "关于"
 
-#: main.lua:699
+#: main.lua:735
 msgid "Bookshelf: open or close"
 msgstr "Bookshelf: 打开/关闭"
 
-#: main.lua:705
+#: main.lua:741
 msgid "Bookshelf: open"
 msgstr "Bookshelf: 打开"
 
-#: main.lua:708
+#: main.lua:744
 msgid "on"
 msgstr "开"
 
-#: main.lua:708
+#: main.lua:744
 msgid "off"
 msgstr "关"
 
-#: main.lua:714
+#: main.lua:750
 msgid "Bookshelf: next chip"
 msgstr "Bookshelf: 下一个分类"
 
-#: main.lua:720
+#: main.lua:756
 msgid "Bookshelf: previous chip"
 msgstr "Bookshelf: 上一个分类"
 
-#: main.lua:726
+#: main.lua:762
 msgid "Bookshelf: expand or collapse hero"
 msgstr "Bookshelf: 展开/折叠 书籍详情"
 
-#: main.lua:732
+#: main.lua:768
 msgid "Bookshelf: toggle selection mode"
 msgstr "Bookshelf: 切换勾选模式"
 
-#: main.lua:739
+#: main.lua:775
 msgid "Bookshelf: toggle selection on focused book"
 msgstr "Bookshelf: 勾选当前书籍"
 
-#: main.lua:745
+#: main.lua:781
 msgid "Bookshelf: add focused stack to selection"
 msgstr "Bookshelf: 全选当前分组"
 
-#: main.lua:751
+#: main.lua:787
 msgid "Bookshelf: open bulk action menu"
 msgstr "Bookshelf: 打开批量操作菜单"
 
-#: main.lua:834
+#: main.lua:870
 msgid "Closing book…"
 msgstr "关闭书籍…"
 
-#: main.lua:1174 lib/bookshelf_settings.lua:2287
-#: lib/bookshelf_settings.lua:2288
+#: main.lua:1236 lib/bookshelf_settings.lua:2969
+#: lib/bookshelf_settings.lua:2970
 msgid "Development branch"
 msgstr "开发分支"
 
-#: main.lua:1176
+#: main.lua:1238
 msgid "Branch name (leave empty for stable)"
 msgstr "分支名称 (留空为稳定版本)"
 
-#: main.lua:1179 lib/bookshelf_bulk_actions.lua:164
+#: main.lua:1241 lib/bookshelf_bulk_actions.lua:164
 #: lib/bookshelf_bulk_actions.lua:379 lib/bookshelf_chip_editor.lua:400
 #: lib/bookshelf_chip_editor.lua:650 lib/bookshelf_chip_editor.lua:1031
 #: lib/bookshelf_chip_editor.lua:1217 lib/bookshelf_collection_manager.lua:333
@@ -147,24 +150,24 @@ msgstr "分支名称 (留空为稳定版本)"
 #: lib/bookshelf_collection_manager.lua:441
 #: lib/bookshelf_collection_manager.lua:491
 #: lib/bookshelf_collection_manager.lua:516 lib/bookshelf_color_palette.lua:352
-#: lib/bookshelf_hero_line_editor.lua:421 lib/bookshelf_settings.lua:1073
-#: lib/bookshelf_settings.lua:1248 lib/bookshelf_settings.lua:1583
-#: lib/bookshelf_settings.lua:1730 lib/bookshelf_settings.lua:1794
-#: lib/bookshelf_settings.lua:1857 lib/bookshelf_settings.lua:1921
-#: lib/bookshelf_widget.lua:3365 lib/bookshelf_widget.lua:7570
-#: lib/bookshelf_widget.lua:7777 lib/bookshelf_widget.lua:8284
-#: lib/bookshelf_widget.lua:8702
+#: lib/bookshelf_hero_line_editor.lua:421 lib/bookshelf_settings.lua:1254
+#: lib/bookshelf_settings.lua:1575 lib/bookshelf_settings.lua:1930
+#: lib/bookshelf_settings.lua:2265 lib/bookshelf_settings.lua:2412
+#: lib/bookshelf_settings.lua:2476 lib/bookshelf_settings.lua:2539
+#: lib/bookshelf_settings.lua:2603 lib/bookshelf_widget.lua:3542
+#: lib/bookshelf_widget.lua:8278 lib/bookshelf_widget.lua:8485
+#: lib/bookshelf_widget.lua:9001 lib/bookshelf_widget.lua:9466
 msgid "Cancel"
 msgstr "取消"
 
-#: main.lua:1184 lib/bookshelf_chip_editor.lua:675
+#: main.lua:1246 lib/bookshelf_chip_editor.lua:675
 #: lib/bookshelf_collection_manager.lua:496
 #: lib/bookshelf_collection_manager.lua:520
 #: lib/bookshelf_hero_line_editor.lua:470
 msgid "Save"
 msgstr "保存"
 
-#: main.lua:1213
+#: main.lua:1275
 msgid ""
 "Book metadata scanner not available.\n"
 "Install the CoverBrowser plugin to enable it."
@@ -172,7 +175,7 @@ msgstr ""
 "图书元数据扫描器不可用。\n"
 "安装 CoverBrowser 插件以启用它。"
 
-#: main.lua:1275
+#: main.lua:1337
 msgid ""
 "This will clear the development branch setting and install the latest stable "
 "release of Bookshelf, then restart KOReader. Continue?"
@@ -180,12 +183,12 @@ msgstr ""
 "这样可以清除开发分支设置，安装最新的 Bookshelf 稳定发布版本，之后会重启 "
 "KOReader。是否继续？"
 
-#: main.lua:1276 lib/bookshelf_bulk_actions.lua:284
-#: lib/bookshelf_settings.lua:1450 lib/bookshelf_settings.lua:1493
+#: main.lua:1338 lib/bookshelf_bulk_actions.lua:284
+#: lib/bookshelf_settings.lua:2132 lib/bookshelf_settings.lua:2175
 msgid "Reset"
 msgstr "重置"
 
-#: main.lua:1297
+#: main.lua:1359
 msgid "Bookshelf update available: v"
 msgstr "「Bookshelf」可更新: v"
 
@@ -194,27 +197,27 @@ msgstr "「Bookshelf」可更新: v"
 msgid "Edit selected (%d)"
 msgstr "编辑所选 (%d)"
 
-#: lib/bookshelf_bulk_actions.lua:110 lib/bookshelf_widget.lua:7643
+#: lib/bookshelf_bulk_actions.lua:110 lib/bookshelf_widget.lua:8351
 msgid "Unopened"
 msgstr "未读"
 
 #: lib/bookshelf_bulk_actions.lua:111 lib/bookshelf_chip_editor.lua:573
-#: lib/bookshelf_chip_editor.lua:1269 lib/bookshelf_widget.lua:7644
+#: lib/bookshelf_chip_editor.lua:1269 lib/bookshelf_widget.lua:8352
 msgid "Reading"
 msgstr "在读"
 
 #: lib/bookshelf_bulk_actions.lua:112 lib/bookshelf_chip_editor.lua:574
-#: lib/bookshelf_chip_editor.lua:1272 lib/bookshelf_widget.lua:7645
+#: lib/bookshelf_chip_editor.lua:1272 lib/bookshelf_widget.lua:8353
 msgid "On hold"
 msgstr "搁置"
 
 #: lib/bookshelf_bulk_actions.lua:113 lib/bookshelf_chip_editor.lua:575
-#: lib/bookshelf_chip_editor.lua:1273 lib/bookshelf_widget.lua:7646
+#: lib/bookshelf_chip_editor.lua:1273 lib/bookshelf_widget.lua:8354
 msgid "Finished"
 msgstr "读完"
 
 #: lib/bookshelf_bulk_actions.lua:124 lib/bookshelf_bulk_actions.lua:126
-#: lib/bookshelf_chip_editor.lua:210 lib/bookshelf_sort_engine.lua:294
+#: lib/bookshelf_chip_editor.lua:210 lib/bookshelf_sort_engine.lua:324
 msgid "Rating"
 msgstr "评分"
 
@@ -222,33 +225,34 @@ msgstr "评分"
 msgid "(clear)"
 msgstr "(清除)"
 
-#: lib/bookshelf_bulk_actions.lua:159 lib/bookshelf_widget.lua:7565
+#: lib/bookshelf_bulk_actions.lua:159 lib/bookshelf_widget.lua:8275
 msgid "Clear"
 msgstr "清除"
 
-#: lib/bookshelf_bulk_actions.lua:167 lib/bookshelf_widget.lua:7573
+#: lib/bookshelf_bulk_actions.lua:167 lib/bookshelf_widget.lua:8281
 msgid "Set rating"
 msgstr "设定评分"
 
 #: lib/bookshelf_bulk_actions.lua:183 lib/bookshelf_bulk_actions.lua:185
-#: lib/bookshelf_bulk_actions.lua:187 lib/bookshelf_widget.lua:7349
+#: lib/bookshelf_bulk_actions.lua:187 lib/bookshelf_widget.lua:7996
 msgid "Favourite"
 msgstr "收藏"
 
 #: lib/bookshelf_bulk_actions.lua:213 lib/bookshelf_chip_editor.lua:197
-#: lib/bookshelf_chip_editor.lua:1203 lib/bookshelf_widget.lua:7383
+#: lib/bookshelf_chip_editor.lua:1203 lib/bookshelf_settings.lua:470
+#: lib/bookshelf_widget.lua:8030
 msgid "Collections"
 msgstr "书单"
 
-#: lib/bookshelf_bulk_actions.lua:245 lib/bookshelf_widget.lua:7460
+#: lib/bookshelf_bulk_actions.lua:245 lib/bookshelf_widget.lua:8107
 msgid "Refresh metadata"
 msgstr "刷新元数据"
 
-#: lib/bookshelf_bulk_actions.lua:258 lib/bookshelf_widget.lua:7322
+#: lib/bookshelf_bulk_actions.lua:258 lib/bookshelf_widget.lua:7969
 msgid "Remove from history"
 msgstr "从历史记录删除"
 
-#: lib/bookshelf_bulk_actions.lua:277 lib/bookshelf_widget.lua:7669
+#: lib/bookshelf_bulk_actions.lua:277 lib/bookshelf_widget.lua:8377
 msgid "Reset book data…"
 msgstr "重置书籍数据…"
 
@@ -258,14 +262,14 @@ msgid "Reset %d books?"
 msgstr "重置 %d 本书籍？"
 
 #: lib/bookshelf_bulk_actions.lua:314 lib/bookshelf_bulk_actions.lua:366
-#: lib/bookshelf_widget.lua:7677 lib/bookshelf_widget.lua:7738
+#: lib/bookshelf_widget.lua:8385 lib/bookshelf_widget.lua:8446
 msgid "Pending changes discarded"
 msgstr "已撤销未保存更改"
 
 #: lib/bookshelf_bulk_actions.lua:328 lib/bookshelf_bulk_actions.lua:344
 #: lib/bookshelf_chip_editor.lua:627 lib/bookshelf_collection_manager.lua:377
-#: lib/bookshelf_collection_manager.lua:407 lib/bookshelf_widget.lua:7700
-#: lib/bookshelf_widget.lua:7717
+#: lib/bookshelf_collection_manager.lua:407 lib/bookshelf_widget.lua:8408
+#: lib/bookshelf_widget.lua:8425
 msgid "Delete"
 msgstr "删除"
 
@@ -280,10 +284,10 @@ msgid "Delete %d books?"
 msgstr "删除 %d 本书籍？"
 
 #: lib/bookshelf_bulk_actions.lua:416 lib/bookshelf_color_palette.lua:356
-#: lib/bookshelf_settings.lua:1076 lib/bookshelf_settings.lua:1251
-#: lib/bookshelf_settings.lua:1615 lib/bookshelf_settings.lua:1797
-#: lib/bookshelf_settings.lua:1860 lib/bookshelf_settings.lua:1924
-#: lib/bookshelf_widget.lua:7781
+#: lib/bookshelf_settings.lua:1257 lib/bookshelf_settings.lua:1933
+#: lib/bookshelf_settings.lua:2297 lib/bookshelf_settings.lua:2479
+#: lib/bookshelf_settings.lua:2542 lib/bookshelf_settings.lua:2606
+#: lib/bookshelf_widget.lua:8489
 msgid "Apply"
 msgstr "应用"
 
@@ -303,7 +307,7 @@ msgid "Apply changes to %d books?"
 msgstr "应用 %d 本书籍的更改？"
 
 #: lib/bookshelf_chip_editor.lua:142 lib/bookshelf_chip_editor.lua:768
-#: lib/bookshelf_settings.lua:2437
+#: lib/bookshelf_settings.lua:3119
 msgid "New chip"
 msgstr "新分类"
 
@@ -311,7 +315,7 @@ msgstr "新分类"
 msgid "Name"
 msgstr "名字"
 
-#: lib/bookshelf_chip_editor.lua:179 lib/bookshelf_sort_engine.lua:210
+#: lib/bookshelf_chip_editor.lua:179 lib/bookshelf_sort_engine.lua:240
 msgid "Surname"
 msgstr "姓氏"
 
@@ -323,7 +327,7 @@ msgstr "最近阅读"
 msgid "Most recently added"
 msgstr "最近添加"
 
-#: lib/bookshelf_chip_editor.lua:182 lib/bookshelf_sort_engine.lua:286
+#: lib/bookshelf_chip_editor.lua:182 lib/bookshelf_sort_engine.lua:316
 msgid "Book count"
 msgstr "书籍数量"
 
@@ -344,20 +348,21 @@ msgid "Latest added"
 msgstr "最后添加"
 
 #: lib/bookshelf_chip_editor.lua:194 lib/bookshelf_chip_editor.lua:207
-#: lib/bookshelf_chip_editor.lua:1188 lib/bookshelf_settings.lua:1169
-#: lib/bookshelf_sort_engine.lua:212 lib/bookshelf_tab_model.lua:50
-#: lib/bookshelf_widget.lua:1064
+#: lib/bookshelf_chip_editor.lua:1188 lib/bookshelf_settings.lua:469
+#: lib/bookshelf_settings.lua:1851 lib/bookshelf_sort_engine.lua:242
+#: lib/bookshelf_tab_model.lua:50 lib/bookshelf_widget.lua:1163
 msgid "Series"
 msgstr "系列"
 
 #: lib/bookshelf_chip_editor.lua:195 lib/bookshelf_chip_editor.lua:1193
 #: lib/bookshelf_settings.lua:77 lib/bookshelf_tab_model.lua:52
-#: lib/bookshelf_widget.lua:1063
+#: lib/bookshelf_widget.lua:1162
 msgid "Authors"
 msgstr "作者"
 
 #: lib/bookshelf_chip_editor.lua:196 lib/bookshelf_chip_editor.lua:1198
-#: lib/bookshelf_tab_model.lua:54 lib/bookshelf_widget.lua:1065
+#: lib/bookshelf_settings.lua:471 lib/bookshelf_tab_model.lua:54
+#: lib/bookshelf_widget.lua:1164
 msgid "Genres"
 msgstr "类型"
 
@@ -366,17 +371,18 @@ msgid "Formats"
 msgstr "格式"
 
 #: lib/bookshelf_chip_editor.lua:199 lib/bookshelf_chip_editor.lua:1212
-#: lib/bookshelf_widget.lua:1068
+#: lib/bookshelf_widget.lua:1167
 msgid "Ratings"
 msgstr "评分"
 
 #: lib/bookshelf_chip_editor.lua:200 lib/bookshelf_collection_manager.lua:118
-#: lib/bookshelf_tab_model.lua:58 lib/bookshelf_widget.lua:6803
-#: lib/bookshelf_widget.lua:6836
+#: lib/bookshelf_tab_model.lua:58 lib/bookshelf_widget.lua:7047
+#: lib/bookshelf_widget.lua:7083
 msgid "Favourites"
 msgstr "收藏夹"
 
-#: lib/bookshelf_chip_editor.lua:202 lib/bookshelf_widget.lua:1067
+#: lib/bookshelf_chip_editor.lua:202 lib/bookshelf_settings.lua:472
+#: lib/bookshelf_widget.lua:1166
 msgid "Folder"
 msgstr "文件夹"
 
@@ -388,8 +394,9 @@ msgstr "书单"
 msgid "Genre"
 msgstr "类型"
 
-#: lib/bookshelf_chip_editor.lua:206 lib/bookshelf_settings.lua:1168
-#: lib/bookshelf_sort_engine.lua:208
+#: lib/bookshelf_chip_editor.lua:206 lib/bookshelf_settings.lua:344
+#: lib/bookshelf_settings.lua:468 lib/bookshelf_settings.lua:1850
+#: lib/bookshelf_sort_engine.lua:238
 msgid "Author"
 msgstr "作者"
 
@@ -402,7 +409,7 @@ msgid "Format"
 msgstr "格式"
 
 #: lib/bookshelf_chip_editor.lua:218 lib/bookshelf_chip_editor.lua:1418
-#: lib/bookshelf_settings.lua:1367
+#: lib/bookshelf_settings.lua:2049
 msgid "(none)"
 msgstr "(无)"
 
@@ -467,14 +474,14 @@ msgid "Choose "
 msgstr "选择 "
 
 #: lib/bookshelf_chip_editor.lua:978 lib/bookshelf_library_modal.lua:371
-#: lib/bookshelf_widget.lua:3341
+#: lib/bookshelf_widget.lua:3518
 msgid "Search…"
 msgstr "搜索…"
 
 #: lib/bookshelf_chip_editor.lua:1004 lib/bookshelf_chip_editor.lua:1341
 #: lib/bookshelf_chip_editor.lua:1442 lib/bookshelf_collection_manager.lua:539
-#: lib/bookshelf_hero_line_editor.lua:94 lib/bookshelf_settings.lua:232
-#: lib/bookshelf_updater.lua:267 lib/bookshelf_widget.lua:7146
+#: lib/bookshelf_hero_line_editor.lua:94 lib/bookshelf_reviews_modal.lua:109
+#: lib/bookshelf_settings.lua:232 lib/bookshelf_updater.lua:267
 msgid "Close"
 msgstr "关闭"
 
@@ -522,7 +529,7 @@ msgstr "分类来源"
 msgid "Any status"
 msgstr "任何状态"
 
-#: lib/bookshelf_chip_editor.lua:1277
+#: lib/bookshelf_chip_editor.lua:1277 lib/bookshelf_widget.lua:7722
 msgid "Done"
 msgstr "完成"
 
@@ -550,11 +557,11 @@ msgstr "先按…排序"
 msgid "Then by"
 msgstr "再按…排序"
 
-#: lib/bookshelf_chip_editor.lua:1419
+#: lib/bookshelf_chip_editor.lua:1419 lib/bookshelf_settings.lua:810
 msgid "Star"
 msgstr "星标"
 
-#: lib/bookshelf_chip_editor.lua:1420
+#: lib/bookshelf_chip_editor.lua:1420 lib/bookshelf_settings.lua:810
 msgid "Heart"
 msgstr "喜欢"
 
@@ -570,12 +577,12 @@ msgstr "播放"
 msgid "Book"
 msgstr "书籍"
 
-#: lib/bookshelf_chip_editor.lua:1424 lib/bookshelf_sort_engine.lua:286
+#: lib/bookshelf_chip_editor.lua:1424 lib/bookshelf_sort_engine.lua:316
 msgid "Books"
 msgstr "书籍(s)"
 
 #: lib/bookshelf_chip_editor.lua:1425 lib/bookshelf_library_modal.lua:407
-#: lib/bookshelf_widget.lua:8707
+#: lib/bookshelf_widget.lua:9471
 msgid "Search"
 msgstr "搜索"
 
@@ -681,10 +688,10 @@ msgid "Page %d of %d"
 msgstr "第 %d / %d 页"
 
 #: lib/bookshelf_color_palette.lua:354 lib/bookshelf_hero_line_editor.lua:89
-#: lib/bookshelf_hero_line_editor.lua:452 lib/bookshelf_settings.lua:791
-#: lib/bookshelf_settings.lua:1074 lib/bookshelf_settings.lua:1249
-#: lib/bookshelf_settings.lua:1593 lib/bookshelf_settings.lua:1795
-#: lib/bookshelf_settings.lua:1858 lib/bookshelf_settings.lua:1922
+#: lib/bookshelf_hero_line_editor.lua:452 lib/bookshelf_settings.lua:961
+#: lib/bookshelf_settings.lua:1255 lib/bookshelf_settings.lua:1931
+#: lib/bookshelf_settings.lua:2275 lib/bookshelf_settings.lua:2477
+#: lib/bookshelf_settings.lua:2540 lib/bookshelf_settings.lua:2604
 msgid "Default"
 msgstr "默认"
 
@@ -700,7 +707,7 @@ msgstr "选择一个颜色"
 msgid "Invalid hex color (use #RGB or #RRGGBB)"
 msgstr "无效的十六进制颜色 (使用 #RGB 或 #RRGGBB)"
 
-#: lib/bookshelf_hero_line_editor.lua:51
+#: lib/bookshelf_hero_line_editor.lua:51 lib/bookshelf_settings.lua:475
 msgid "Font size"
 msgstr "字体大小"
 
@@ -741,25 +748,21 @@ msgid "Bar style"
 msgstr "栏样式"
 
 #: lib/bookshelf_hero_line_editor.lua:373
-#, fuzzy
 msgid "Bar: "
-msgstr "Bar: "
+msgstr "栏: "
 
 #: lib/bookshelf_hero_line_editor.lua:386
-#, fuzzy
 msgid "- Bar"
-msgstr "- Bar"
+msgstr "- 栏"
 
 #: lib/bookshelf_hero_line_editor.lua:386
-#, fuzzy
 msgid "+ Bar"
-msgstr "+ Bar"
+msgstr "+ 栏"
 
 #: lib/bookshelf_hero_line_editor.lua:396
 #: lib/bookshelf_hero_line_editor.lua:411
-#, fuzzy
 msgid "Bar height"
-msgstr "Bar高度"
+msgstr "栏高度"
 
 #: lib/bookshelf_hero_line_editor.lua:397
 msgid "Height: "
@@ -785,11 +788,20 @@ msgstr "书籍"
 msgid "books"
 msgstr "书籍(s)"
 
+#: lib/bookshelf_reviews_modal.lua:85 lib/bookshelf_widget.lua:8182
+msgid "Hardcover reviews"
+msgstr "Hardcover 书评"
+
+#: lib/bookshelf_reviews_modal.lua:97
+msgid "Refresh"
+msgstr "刷新"
+
 #: lib/bookshelf_settings.lua:75
 msgid "All"
 msgstr "全部"
 
-#: lib/bookshelf_settings.lua:78 lib/bookshelf_sort_engine.lua:240
+#: lib/bookshelf_settings.lua:78 lib/bookshelf_settings.lua:349
+#: lib/bookshelf_sort_engine.lua:270
 msgid "Progress"
 msgstr "进度"
 
@@ -846,168 +858,225 @@ msgstr "搜索占位符…"
 msgid "Help"
 msgstr "帮助"
 
-#: lib/bookshelf_settings.lua:339
+#: lib/bookshelf_settings.lua:342
+msgid "Status line"
+msgstr "状态条"
+
+#: lib/bookshelf_settings.lua:343 lib/bookshelf_settings.lua:1849
+#: lib/bookshelf_sort_engine.lua:220
+msgid "Title"
+msgstr "标题"
+
+#: lib/bookshelf_settings.lua:345
 msgid "Rating (interactive)"
 msgstr "评分 (可交互)"
 
-#: lib/bookshelf_settings.lua:340
+#: lib/bookshelf_settings.lua:346
+msgid "Metadata"
+msgstr "元数据"
+
+#: lib/bookshelf_settings.lua:347 lib/bookshelf_widget.lua:7401
+msgid "Description"
+msgstr "描述"
+
+#: lib/bookshelf_settings.lua:348
 msgid "Tags (interactive)"
 msgstr "标签 (可交互)"
 
-#: lib/bookshelf_settings.lua:450
+#: lib/bookshelf_settings.lua:459
+msgid "Show tags line"
+msgstr "显示标签行"
+
+#: lib/bookshelf_settings.lua:495
+msgid "Tags font size"
+msgstr "标签字体大小"
+
+#: lib/bookshelf_settings.lua:501 lib/bookshelf_settings.lua:506
+msgid "Left"
+msgstr "左"
+
+#: lib/bookshelf_settings.lua:501 lib/bookshelf_settings.lua:507
+msgid "Centre"
+msgstr "中"
+
+#: lib/bookshelf_settings.lua:501 lib/bookshelf_settings.lua:508
+msgid "Right"
+msgstr "右"
+
+#: lib/bookshelf_settings.lua:502
+msgid "Alignment"
+msgstr "对齐"
+
+#: lib/bookshelf_settings.lua:578
 msgid "Show reading bookmarks"
 msgstr "显示阅读书签"
 
-#: lib/bookshelf_settings.lua:476 lib/bookshelf_settings.lua:1170
-#: lib/bookshelf_shelf_row.lua:202
+#: lib/bookshelf_settings.lua:580
+msgid "Show on-hold badge"
+msgstr "显示搁置徽章"
+
+#: lib/bookshelf_settings.lua:606 lib/bookshelf_settings.lua:1852
+#: lib/bookshelf_shelf_row.lua:213
 msgid "None"
 msgstr "无"
 
-#: lib/bookshelf_settings.lua:477
+#: lib/bookshelf_settings.lua:607
 msgid "Bookmark style"
 msgstr "书签样式"
 
-#: lib/bookshelf_settings.lua:478
+#: lib/bookshelf_settings.lua:608
 msgid "Small tick box"
 msgstr "小勾选框"
 
-#: lib/bookshelf_settings.lua:493
+#: lib/bookshelf_settings.lua:623
 msgid "Completed book badge"
 msgstr "已读完徽章"
 
-#: lib/bookshelf_settings.lua:525
+#: lib/bookshelf_settings.lua:655
 msgid "Always"
 msgstr "总是"
 
-#: lib/bookshelf_settings.lua:526
+#: lib/bookshelf_settings.lua:656
 msgid "Within series folder"
 msgstr "在系列文件夹内"
 
-#: lib/bookshelf_settings.lua:527
+#: lib/bookshelf_settings.lua:657
 msgid "Never"
 msgstr "从不"
 
-#: lib/bookshelf_settings.lua:542
+#: lib/bookshelf_settings.lua:672
 msgid "Show series #"
 msgstr "显示系列#"
 
-#: lib/bookshelf_settings.lua:578
+#: lib/bookshelf_settings.lua:708
 msgid "Off"
 msgstr "关闭"
 
-#: lib/bookshelf_settings.lua:579
+#: lib/bookshelf_settings.lua:709
 msgid "Folders only"
 msgstr "仅限文件夹"
 
-#: lib/bookshelf_settings.lua:580
+#: lib/bookshelf_settings.lua:710
 msgid "Groups only"
 msgstr "仅限分组"
 
-#: lib/bookshelf_settings.lua:581
+#: lib/bookshelf_settings.lua:711
 msgid "All stacks"
 msgstr "堆叠所有"
 
-#: lib/bookshelf_settings.lua:596
+#: lib/bookshelf_settings.lua:726
 msgid "Stack count badge"
 msgstr "堆叠计数徽章"
 
-#: lib/bookshelf_settings.lua:627
+#: lib/bookshelf_settings.lua:757
 msgid "Total"
 msgstr "总计"
 
-#: lib/bookshelf_settings.lua:628
+#: lib/bookshelf_settings.lua:758
 msgid "Finished / Total"
 msgstr "完成 / 总计"
 
-#: lib/bookshelf_settings.lua:643
+#: lib/bookshelf_settings.lua:773
 msgid "Stack count format"
 msgstr "堆叠计数格式"
 
-#: lib/bookshelf_settings.lua:654
+#: lib/bookshelf_settings.lua:784
 msgid "Show progress bars"
 msgstr "显示进度条"
 
-#: lib/bookshelf_settings.lua:658
+#: lib/bookshelf_settings.lua:788
 msgid "Show page count"
 msgstr "显示页数"
 
-#: lib/bookshelf_settings.lua:663
-msgid "Show favourites star"
-msgstr "显示收藏星标"
+#: lib/bookshelf_settings.lua:795
+msgid "Show favourites icon"
+msgstr "显示收藏图标"
 
-#: lib/bookshelf_settings.lua:709 lib/bookshelf_settings.lua:726
+#: lib/bookshelf_settings.lua:824
+msgid "Favourite icon"
+msgstr "收藏图标"
+
+#: lib/bookshelf_settings.lua:879 lib/bookshelf_settings.lua:896
 msgid "default"
 msgstr "默认"
 
-#: lib/bookshelf_settings.lua:805
+#: lib/bookshelf_settings.lua:975
 msgid "◐ Editing night-mode colors (tap to switch)"
 msgstr "◐ 编辑夜间模式颜色 (点击切换)"
 
-#: lib/bookshelf_settings.lua:807
+#: lib/bookshelf_settings.lua:977
 msgid "☀ Editing day-mode colors (tap to switch)"
 msgstr "☀ 编辑白天模式颜色 (点击切换)"
 
-#: lib/bookshelf_settings.lua:828
+#: lib/bookshelf_settings.lua:998
 msgid "Progress bar"
 msgstr "进度条"
 
-#: lib/bookshelf_settings.lua:833
+#: lib/bookshelf_settings.lua:1003
 msgid "Progress bar (% black)"
 msgstr "进度条  (% 黑色)"
 
-#: lib/bookshelf_settings.lua:843
+#: lib/bookshelf_settings.lua:1013
 msgid "Progress bar track"
 msgstr "进度条轨道"
 
-#: lib/bookshelf_settings.lua:848
+#: lib/bookshelf_settings.lua:1018
 msgid "Progress bar track (% black)"
 msgstr "进度条轨道  (% 黑色)"
 
-#: lib/bookshelf_settings.lua:858
+#: lib/bookshelf_settings.lua:1028
 msgid "Bookmark color"
 msgstr "书签颜色"
 
-#: lib/bookshelf_settings.lua:863
+#: lib/bookshelf_settings.lua:1033
 msgid "Bookmark color (% black)"
 msgstr "书签颜色 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:873
+#: lib/bookshelf_settings.lua:1043
 msgid "Finished bookmark color"
 msgstr "已读完书签颜色"
 
-#: lib/bookshelf_settings.lua:879
+#: lib/bookshelf_settings.lua:1049
 msgid "Finished bookmark color (% black)"
 msgstr "已读书签颜色 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:889
+#: lib/bookshelf_settings.lua:1063
+msgid "Favourite heart color"
+msgstr "收藏爱心颜色"
+
+#: lib/bookshelf_settings.lua:1063
 msgid "Favourite star color"
 msgstr "收藏星标颜色"
 
-#: lib/bookshelf_settings.lua:895
+#: lib/bookshelf_settings.lua:1071
+msgid "Favourite heart color (% black)"
+msgstr "收藏爱心颜色 (% 黑色)"
+
+#: lib/bookshelf_settings.lua:1074
 msgid "Favourite star color (% black)"
 msgstr "收藏星标颜色 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:905
+#: lib/bookshelf_settings.lua:1086
 msgid "Badge foreground"
 msgstr "徽章前景"
 
-#: lib/bookshelf_settings.lua:910
+#: lib/bookshelf_settings.lua:1091
 msgid "Badge foreground (% black)"
 msgstr "徽章前景 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:920
+#: lib/bookshelf_settings.lua:1101
 msgid "Badge background"
 msgstr "徽章背景"
 
-#: lib/bookshelf_settings.lua:925
+#: lib/bookshelf_settings.lua:1106
 msgid "Badge background (% black)"
 msgstr "徽章背景 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:935
+#: lib/bookshelf_settings.lua:1116
 msgid "Border color"
 msgstr "边框颜色"
 
-#: lib/bookshelf_settings.lua:937
+#: lib/bookshelf_settings.lua:1118
 msgid ""
 "Color of the book cover frame border + pill badge / page-count badge "
 "borders. Badge foreground is now just badge text. Default black."
@@ -1015,23 +1084,23 @@ msgstr ""
 "封面边框 + 胶囊徽标 / 页数徽标边框颜色。徽标前景色仅控制徽标文字。默认值为黑"
 "色。"
 
-#: lib/bookshelf_settings.lua:943
+#: lib/bookshelf_settings.lua:1124
 msgid "Border color (% black)"
 msgstr "边框颜色 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:953
+#: lib/bookshelf_settings.lua:1134
 msgid "Folder overlay background"
 msgstr "文件夹叠加背景"
 
-#: lib/bookshelf_settings.lua:958
+#: lib/bookshelf_settings.lua:1139
 msgid "Folder overlay background (% black)"
 msgstr "文件夹叠加背景 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:968
+#: lib/bookshelf_settings.lua:1149
 msgid "Folder text color"
 msgstr "文件夹文本颜色"
 
-#: lib/bookshelf_settings.lua:970
+#: lib/bookshelf_settings.lua:1151
 msgid ""
 "Color of the label text inside folder / series / author / genre / tag cards. "
 "The cardboard outline around the card itself follows the Border color "
@@ -1040,23 +1109,23 @@ msgstr ""
 "标签文字颜色在 文件夹/丛书/作者/分类/标签 卡片上。卡片外边框沿用边框颜色配"
 "置。"
 
-#: lib/bookshelf_settings.lua:977
+#: lib/bookshelf_settings.lua:1158
 msgid "Folder text color (% black)"
 msgstr "文件夹文本颜色 (% 黑色)"
 
-#: lib/bookshelf_settings.lua:986
+#: lib/bookshelf_settings.lua:1167
 msgid "Reset to default colors"
 msgstr "重置为默认颜色"
 
-#: lib/bookshelf_settings.lua:1062
-msgid "Badge font scale"
-msgstr "徽章字体比例"
+#: lib/bookshelf_settings.lua:1243
+msgid "Cover badge size"
+msgstr "封面徽章大小"
 
-#: lib/bookshelf_settings.lua:1095 lib/bookshelf_settings.lua:1712
+#: lib/bookshelf_settings.lua:1276 lib/bookshelf_settings.lua:2394
 msgid "Edit layout"
 msgstr "编辑布局"
 
-#: lib/bookshelf_settings.lua:1096
+#: lib/bookshelf_settings.lua:1277
 msgid ""
 "Open a small overlay that lets you cycle through bookshelf cover size and "
 "hero size with the bookshelf visible behind it. Changes preview in realtime; "
@@ -1065,60 +1134,331 @@ msgstr ""
 "弹出小型悬浮面板，可在书架页面可见状态下循环切换封面尺寸与书籍详情尺寸。修改"
 "实时预览，点击确认保存设置、点击撤销恢复原有参数。"
 
-#: lib/bookshelf_settings.lua:1106
+#: lib/bookshelf_settings.lua:1287
 msgid "Cover display"
 msgstr "封面显示"
 
-#: lib/bookshelf_settings.lua:1112
+#: lib/bookshelf_settings.lua:1293
 msgid "Text size"
 msgstr "字体大小"
 
-#: lib/bookshelf_settings.lua:1118
+#: lib/bookshelf_settings.lua:1299
 msgid "Colors"
 msgstr "颜色"
 
-#: lib/bookshelf_settings.lua:1124
+#: lib/bookshelf_settings.lua:1305
 msgid "Expanded shelf"
 msgstr "展开书架"
 
-#: lib/bookshelf_settings.lua:1130
+#: lib/bookshelf_settings.lua:1315
 msgid "Advanced settings"
 msgstr "高级设置"
 
-#: lib/bookshelf_settings.lua:1167 lib/bookshelf_sort_engine.lua:190
-msgid "Title"
-msgstr "标题"
+#: lib/bookshelf_settings.lua:1325
+msgid "never"
+msgstr "从不"
 
-#: lib/bookshelf_settings.lua:1186
+#: lib/bookshelf_settings.lua:1432
+msgid "Hardcover plugin is not available"
+msgstr "Hardcover 插件暂不可用"
+
+#: lib/bookshelf_settings.lua:1447
+msgid "No unlinked books to auto-link."
+msgstr "没有待关联的书籍。"
+
+#: lib/bookshelf_settings.lua:1470
+msgid "Auto-link report"
+msgstr "自动关联报告"
+
+#: lib/bookshelf_settings.lua:1547
+msgid ""
+"Auto-linking from Hardcover…\n"
+"\n"
+"%1 / %2 checked  ·  %3 linked\n"
+"\n"
+"(tap to cancel)"
+msgstr ""
+"正在从 Hardcover 自动关联…\n"
+"已检查 %1 / %2 项・已关联 %3 项\n"
+"（点击取消）"
+
+#: lib/bookshelf_settings.lua:1562
+msgid ""
+"Auto-link %1 unlinked book(s)?\n"
+"\n"
+"Contacts Hardcover (rate-limited), up to ~%2 min. Cancellable, with a report "
+"at the end."
+msgstr ""
+"是否自动关联 %1 本未关联书籍？\n"
+"\n"
+"将访问 Hardcover（存在访问频次限制）：预计耗时约 %2 分钟。可取消，完成后将生"
+"成报告。"
+
+#: lib/bookshelf_settings.lua:1567
+msgid "Exact match (ISBN / Hardcover id)"
+msgstr "精确匹配 (ISBN / Hardcover id)"
+
+#: lib/bookshelf_settings.lua:1571
+msgid "Best guess (title & author)"
+msgstr "智能匹配（书名 & 作者）"
+
+#: lib/bookshelf_settings.lua:1588
+msgid "Cached Hardcover ratings: unavailable"
+msgstr "缓存 Hardcover 评分: 不可用"
+
+#: lib/bookshelf_settings.lua:1591
+#, lua-format
+msgid "Cached Hardcover ratings: %d/%d · %s"
+msgstr "缓存 Hardcover 评分: %d/%d · %s"
+
+#: lib/bookshelf_settings.lua:1601
+msgid "Auto-link all books"
+msgstr "自动关联所有书籍"
+
+#: lib/bookshelf_settings.lua:1602
+msgid ""
+"Scan the library and link books to Hardcover, fetching each match's details "
+"(description, cover, rating) in the same pass. Choose Exact match (uses an "
+"embedded ISBN / Hardcover id, fast) or Best guess (searches by title and "
+"author and picks the most confident match, slower but catches books with no "
+"embedded id). A report at the end lists exactly what was linked. Contacts "
+"Hardcover (rate-limited) with cancellable progress."
+msgstr ""
+"扫描书库并将书籍关联至 Hardcover，同步获取匹配项的详情（简介、封面、评"
+"分）。\n"
+"可选择精准匹配（依托内置 ISBN / Hardcover 编号，速度更快）或智能推测匹配（根"
+"据书名与作者检索，选取可信度最高的结果；速度较慢，但可识别无内置编号的书"
+"籍）。\n"
+"操作结束后会生成报告，详细列出所有已关联条目。该功能会访问 Hardcover（存在访"
+"问频次限制），运行过程可随时取消。"
+
+#: lib/bookshelf_settings.lua:1612
+msgid "Show Hardcover ratings in hero"
+msgstr "在书籍详情显示 Hardcover 评分"
+
+#: lib/bookshelf_settings.lua:1613
+msgid ""
+"When enabled, the Hero rating row shows the cached public Hardcover rating "
+"instead of KOReader's local rating. Enabling this also turns on the Hero "
+"rating row. Normal Bookshelf rendering only reads the local cache."
+msgstr ""
+"开启后，书籍详情评分行将展示 Hardcover 公开缓存评分，而非 KOReader 本地评分。"
+"启用本项会同时显示书籍详情评分行。常规书架界面仅读取本地缓存数据。"
+
+#: lib/bookshelf_settings.lua:1636
+msgid "Use Hardcover metadata"
+msgstr "使用 Hardcover 元数据"
+
+#: lib/bookshelf_settings.lua:1637
+msgid ""
+"For books linked to Hardcover, show Hardcover's title, author, series and "
+"genres in place of the book's own -- a clean switch, no merging. Covers and "
+"descriptions stay under their per-book toggles. This affects sorting, search "
+"and series grouping for linked books; non-linked books are unaffected. "
+"Metadata is always cached, so this only decides whether it's used."
+msgstr ""
+"已关联 Hardcover 的书籍，将使用其对应的书名、作者、系列及分类信息替换书籍原有"
+"元数据（数据不合并）。封面与简介仍保留在书籍独立开关项中。\n"
+"该设置会影响已关联书籍的排序、搜索及系列分组，未关联书籍不受影响。相关元数据"
+"会持续缓存，本选项仅控制是否启用该套数据。"
+
+#: lib/bookshelf_settings.lua:1652
+msgid "Download covers from Hardcover"
+msgstr "从 Hardcover 下载封面"
+
+#: lib/bookshelf_settings.lua:1653
+msgid ""
+"When on, linking a book also downloads its Hardcover cover and stores it as "
+"the book's cover. Off by default: most books already have a cover, and "
+"downloaded covers use storage and get picked up by the library metadata "
+"scan. Descriptions, ratings and metadata are fetched either way; turn this "
+"on only if you want Hardcover covers too."
+msgstr ""
+"开启后，关联书籍时会同步下载 Hardcover 封面并设为书籍默认封面。默认关闭：多数"
+"书籍已自带封面，下载封面会占用存储空间，且会被书库元数据扫描识别。无论该选项"
+"开启与否，简介、评分及其他元数据均会正常获取；仅在需要使用 Hardcover 封面时开"
+"启即可。"
+
+#: lib/bookshelf_settings.lua:1669
+msgid "Hardcover genres used: %1"
+msgstr "已启用 Hardcover 题材：%1"
+
+#: lib/bookshelf_settings.lua:1671
+msgid ""
+"How many of a linked book's Hardcover genres to use -- for the tag pills and "
+"the genre chips/stacks -- when Use Hardcover metadata is on. 0 uses none."
+msgstr ""
+"设置从已关联书籍中调取多少项 Hardcover 题材，用于标签色块与题材的分类/堆叠——"
+"在开启「使用 Hardcover 元数据」时生效。设为 0 则不启用任何分类。"
+
+#: lib/bookshelf_settings.lua:1680
+msgid "Hardcover genres used"
+msgstr "已启用 Hardcover 题材"
+
+#: lib/bookshelf_settings.lua:1681
+msgid ""
+"How many of a book's Hardcover genres to use for tag pills and the genre "
+"chips/stacks."
+msgstr "选取书籍的 Hardcover 题材数量，用于展示标签色块与题材的分类/堆叠。"
+
+#: lib/bookshelf_settings.lua:1687
+msgid "Set"
+msgstr "设置"
+
+#: lib/bookshelf_settings.lua:1701
+msgid "Manage Hardcover data"
+msgstr "管理 Hardcover 数据"
+
+#: lib/bookshelf_settings.lua:1708
+msgid "Refresh ratings only"
+msgstr "仅刷新评分"
+
+#: lib/bookshelf_settings.lua:1709
+msgid ""
+"Fetch up-to-date public ratings and review counts for linked Hardcover "
+"books. Covers and descriptions are fetched when a book is linked, so this "
+"only updates the ratings."
+msgstr ""
+"为已关联 Hardcover 的书籍获取最新公开评分与评论数。封面和简介仅在书籍关联时拉"
+"取，本功能仅更新评分数据。"
+
+#: lib/bookshelf_settings.lua:1717 lib/bookshelf_widget.lua:7419
+#: lib/bookshelf_widget.lua:7560
+msgid "Hardcover integration could not be loaded"
+msgstr "无法加载 Hardcover 集成组件"
+
+#: lib/bookshelf_settings.lua:1720
+msgid "Fetching Hardcover ratings..."
+msgstr "正在获取 Hardcover 评分…"
+
+#: lib/bookshelf_settings.lua:1723
+msgid "Hardcover ratings refresh failed"
+msgstr "Hardcover 评分刷新失败"
+
+#: lib/bookshelf_settings.lua:1728
+msgid "Hardcover ratings refreshed: %1 rated of %2 linked books"
+msgstr "Hardcover 评分已刷新：成功更新 %1 本，共 %2 本关联书籍"
+
+#: lib/bookshelf_settings.lua:1738
+msgid "Clear cache (keeps links)"
+msgstr "清除缓存（保留关联关系）"
+
+#: lib/bookshelf_settings.lua:1739
+msgid ""
+"Remove Bookshelf's cached Hardcover descriptions, cover images, ratings, "
+"review counts and review text. Existing book links are kept, so you can "
+"refresh again later."
+msgstr ""
+"清除书架中缓存的 Hardcover 简介、封面图片、评分、评论数量及评论内容。已建立的"
+"书籍关联关系会保留，后续可重新刷新数据。"
+
+#: lib/bookshelf_settings.lua:1752
+msgid "Hardcover cache cleared"
+msgstr "Hardcover 缓存已清除"
+
+#: lib/bookshelf_settings.lua:1760
+msgid "Remove downloaded covers"
+msgstr "删除已下载的封面"
+
+#: lib/bookshelf_settings.lua:1761
+msgid ""
+"Delete every downloaded Hardcover cover and restore each book's original "
+"cover, keeping links, descriptions and ratings. Frees the storage the covers "
+"use and clears them out of the library metadata scan."
+msgstr ""
+"删除所有已下载的 Hardcover 封面，并恢复书籍原始封面。关联关系、简介与评分均予"
+"以保留。此举可释放封面占用的存储空间，同时在书库元数据扫描中清除对应封面记"
+"录。"
+
+#: lib/bookshelf_settings.lua:1765
+msgid ""
+"Remove all downloaded Hardcover covers?\n"
+"\n"
+"Each book's original cover is restored; links, descriptions and ratings are "
+"kept."
+msgstr ""
+"是否删除所有已下载的 Hardcover 封面？\n"
+"\n"
+"操作后将恢复书籍原始封面，关联关系、简介及评分均保留。"
+
+#: lib/bookshelf_settings.lua:1766
+msgid "Remove covers"
+msgstr "删除封面"
+
+#: lib/bookshelf_settings.lua:1779
+msgid "Removed downloaded covers (%1 book(s))."
+msgstr "删除已下载的封面 (%1 本书)。"
+
+#: lib/bookshelf_settings.lua:1789
+msgid "Remove all Hardcover data"
+msgstr "删除所有 Hardcover 数据"
+
+#: lib/bookshelf_settings.lua:1790
+msgid ""
+"Unlink every book and delete all cached Hardcover descriptions, covers, "
+"ratings and reviews, resetting the library to how it was before any "
+"Hardcover linking. Only covers Hardcover added are removed; a cover you had "
+"before is restored. Cannot be undone."
+msgstr ""
+"解除所有书籍的关联，并删除全部缓存的 Hardcover 简介、封面、评分与评论，将书库"
+"恢复至关联功能启用前的状态。仅移除通过 Hardcover 添加的封面，恢复书籍原有封"
+"面。此操作无法撤销。"
+
+#: lib/bookshelf_settings.lua:1794
+msgid ""
+"Remove ALL Hardcover data?\n"
+"\n"
+"This unlinks every book and deletes all cached Hardcover covers, "
+"descriptions, ratings and reviews. Covers Hardcover saved into book folders "
+"are removed and any cover you had before is put back.\n"
+"\n"
+"This cannot be undone."
+msgstr ""
+"是否清除全部 Hardcover 数据？\n"
+"\n"
+"该操作会解除所有书籍关联，并删除缓存的封面、简介、评分及评论。移除保存在书籍"
+"目录下的 Hardcover 封面，恢复书籍原始封面。\n"
+"\n"
+"操作无法撤销。"
+
+#: lib/bookshelf_settings.lua:1795
+msgid "Remove all"
+msgstr "删除全部"
+
+#: lib/bookshelf_settings.lua:1808
+msgid "All Hardcover data removed (%1 book(s) unlinked)."
+msgstr "已清除全部 Hardcover 数据（共解除 %1 本书的关联）"
+
+#: lib/bookshelf_settings.lua:1868
 msgid "Show text below covers"
 msgstr "封面下方显示文本"
 
-#: lib/bookshelf_settings.lua:1237
+#: lib/bookshelf_settings.lua:1919
 msgid "Expanded shelf font scale"
 msgstr "展开书架字体比例"
 
-#: lib/bookshelf_settings.lua:1266
+#: lib/bookshelf_settings.lua:1948
 msgid "Scan all library metadata"
 msgstr "扫描全库元数据"
 
-#: lib/bookshelf_settings.lua:1277 lib/bookshelf_settings.lua:1280
-#: lib/bookshelf_settings.lua:1312
+#: lib/bookshelf_settings.lua:1959 lib/bookshelf_settings.lua:1962
+#: lib/bookshelf_settings.lua:1994
 msgid "Auto"
 msgstr "自动"
 
-#: lib/bookshelf_settings.lua:1278 lib/bookshelf_settings.lua:1313
+#: lib/bookshelf_settings.lua:1960 lib/bookshelf_settings.lua:1995
 msgid "First Last"
 msgstr "名称 姓氏"
 
-#: lib/bookshelf_settings.lua:1279 lib/bookshelf_settings.lua:1314
+#: lib/bookshelf_settings.lua:1961 lib/bookshelf_settings.lua:1996
 msgid "Last, First"
 msgstr "姓氏，名字"
 
-#: lib/bookshelf_settings.lua:1281
+#: lib/bookshelf_settings.lua:1963
 msgid "Author name formatting"
 msgstr "作者姓名格式"
 
-#: lib/bookshelf_settings.lua:1283
+#: lib/bookshelf_settings.lua:1965
 msgid ""
 "How author names are displayed on the Authors chip. Auto keeps whichever "
 "form was first found (\"Richard Osman\" or \"Osman, Richard\"). First Last "
@@ -1129,15 +1469,15 @@ msgstr ""
 "或 Osman, Richard)；「名称 姓氏」「姓氏， 名字」会强制统一所有作者排版，不受"
 "书籍原始存储格式影响。"
 
-#: lib/bookshelf_settings.lua:1319
+#: lib/bookshelf_settings.lua:2001
 msgid "\"Latest\" walk depth"
 msgstr "新书遍历深度"
 
-#: lib/bookshelf_settings.lua:1324
+#: lib/bookshelf_settings.lua:2006
 msgid "Cover cache"
 msgstr "封面缓存"
 
-#: lib/bookshelf_settings.lua:1328
+#: lib/bookshelf_settings.lua:2010
 msgid ""
 "How much memory to use for ready-scaled book covers. A bigger cache keeps "
 "more covers warm -- smoother paging and preloading -- at the cost of RAM. "
@@ -1150,11 +1490,11 @@ msgstr ""
 "值，内存充裕则适当调高。 (可缓存封面数量受单张大小影响: 小型灰度封面约可存 "
 "200～400 张，大图或彩色封面存量更少。)"
 
-#: lib/bookshelf_settings.lua:1340
+#: lib/bookshelf_settings.lua:2022
 msgid "Clear cover cache"
 msgstr "清除封面缓存"
 
-#: lib/bookshelf_settings.lua:1341
+#: lib/bookshelf_settings.lua:2023
 msgid ""
 "Drop all cached scaled covers from memory. Use this when a book's cover has "
 "been updated outside KOReader (e.g. a metadata-enrichment tool rewrote the "
@@ -1165,15 +1505,15 @@ msgstr ""
 "写 EPUB 文件)，书架仍显示旧封面时可使用本功能；下次加载会从 EPUB 重新读取最新"
 "封面，重启 KOReader 效果一致。"
 
-#: lib/bookshelf_settings.lua:1352
+#: lib/bookshelf_settings.lua:2034
 msgid "Cover cache cleared"
 msgstr "封面缓存已清除"
 
-#: lib/bookshelf_settings.lua:1367
+#: lib/bookshelf_settings.lua:2049
 msgid "Image library"
 msgstr "图片库"
 
-#: lib/bookshelf_settings.lua:1370
+#: lib/bookshelf_settings.lua:2052
 msgid ""
 "Where Bookshelf looks for custom cover images. For stacks, place files like "
 "authors/author-name.jpg into the matching subfolder (authors, series, "
@@ -1184,11 +1524,11 @@ msgstr ""
 "放入对应子目录 (作者、丛书、分类、合集文件夹)；文件夹封面直接在目录内放入 "
 "cover.jpg 即可，更多匹配规则参阅说明文档。"
 
-#: lib/bookshelf_settings.lua:1376
+#: lib/bookshelf_settings.lua:2058
 msgid "Double tap to open books"
 msgstr "通过双击打开书籍"
 
-#: lib/bookshelf_settings.lua:1377
+#: lib/bookshelf_settings.lua:2059
 msgid ""
 "When enabled, opening a book from the hero card or from a shelf cover in "
 "expanded mode requires two taps -- the first selects the cover (focus ring), "
@@ -1202,11 +1542,11 @@ msgstr ""
 "常规书架封面 (显示头部大图) 本身已是该交互逻辑：单击将图书设为书籍详情预览，"
 "点击书籍详情打开书籍，不受本选项控制。"
 
-#: lib/bookshelf_settings.lua:1401
+#: lib/bookshelf_settings.lua:2083
 msgid "Closing book notification"
 msgstr "退出书籍提醒"
 
-#: lib/bookshelf_settings.lua:1402
+#: lib/bookshelf_settings.lua:2084
 msgid ""
 "Show a 'Closing book…' message in the centre of the screen while a book is "
 "being closed back to Bookshelf. The book-close work takes a moment, so the "
@@ -1218,15 +1558,15 @@ msgstr ""
 "该提示用于反馈操作已生效。部分彩色墨水屏设备会因弹窗闪现短暂屏闪，如需消除提"
 "示与闪屏可在此关闭。"
 
-#: lib/bookshelf_settings.lua:1422
+#: lib/bookshelf_settings.lua:2104
 msgid "Follow KOReader"
 msgstr "跟随 KOReader 设置"
 
-#: lib/bookshelf_settings.lua:1424
+#: lib/bookshelf_settings.lua:2106
 msgid "Bookshelf UI font: %1"
 msgstr "书架界面字体: %1"
 
-#: lib/bookshelf_settings.lua:1426
+#: lib/bookshelf_settings.lua:2108
 msgid ""
 "The font Bookshelf uses for its own UI text (chips, labels, metadata). Pick "
 "any installed font (same picker as the hero card); '(Default)' follows your "
@@ -1237,11 +1577,11 @@ msgstr ""
 "情卡片相同)；'(默认)' 选项同步 KOReader 全局界面字体。书籍详情的书名、作者字"
 "体需在书籍详情卡片编辑面板单独设置。"
 
-#: lib/bookshelf_settings.lua:1434
+#: lib/bookshelf_settings.lua:2116
 msgid "Reset chip bar to defaults"
 msgstr "将分类栏重置为默认值"
 
-#: lib/bookshelf_settings.lua:1435
+#: lib/bookshelf_settings.lua:2117
 msgid ""
 "Clears your custom chip layout (which chips are shown, their order, their "
 "labels and icons, their sources and filters and sorts) and restores the "
@@ -1255,7 +1595,7 @@ msgstr ""
 "手动开启。同时将当前选中标签切回首页、页码重置为 1。书籍详情文字、字体、配色"
 "等其他设置保持不变。"
 
-#: lib/bookshelf_settings.lua:1446
+#: lib/bookshelf_settings.lua:2128
 msgid ""
 "Reset the chip bar to default settings?\n"
 "\n"
@@ -1267,11 +1607,11 @@ msgstr ""
 "所有自行新增、修改的自定义分类将会被清除；书架其余配置 (书籍详情文字、字体、"
 "配色)保持不变。"
 
-#: lib/bookshelf_settings.lua:1482
+#: lib/bookshelf_settings.lua:2164
 msgid "Reset book detail area to defaults"
 msgstr "重置书籍详情区域为默认值"
 
-#: lib/bookshelf_settings.lua:1483
+#: lib/bookshelf_settings.lua:2165
 msgid ""
 "Clears your hero/book-detail customizations and restores the fresh-install "
 "detail layout, including the bundled title (Inter ExtraBold) and author "
@@ -1281,7 +1621,7 @@ msgstr ""
 "ExtraBold)、作者字体 (Caveat)一并还原为预设样式。书架界面字体、顶部贴片栏配置"
 "不受改动。"
 
-#: lib/bookshelf_settings.lua:1490
+#: lib/bookshelf_settings.lua:2172
 msgid ""
 "Reset the book detail area to default settings?\n"
 "\n"
@@ -1292,11 +1632,11 @@ msgstr ""
 "\n"
 "所有书籍详情的文字、字体自定义设置将会清空；书架界面字体、分类栏保持不变。"
 
-#: lib/bookshelf_settings.lua:1508
+#: lib/bookshelf_settings.lua:2190
 msgid "BETA: Read calibre metadata.calibre"
 msgstr "BETA: 读取 caliber 的 metadata.calibre"
 
-#: lib/bookshelf_settings.lua:1509
+#: lib/bookshelf_settings.lua:2191
 msgid ""
 "For users with a Calibre-managed library. Reads the metadata.calibre JSON "
 "file at home_dir to cover title / authors / series / tags / language for "
@@ -1307,75 +1647,75 @@ msgstr ""
 "量补全全库书籍的书名、作者、丛书、标签、语种信息，无需逐本解析电子书提取元数"
 "据。各字段优先采用 BIM 缓存数据，Calibre 数据仅用来填补空缺内容。"
 
-#: lib/bookshelf_settings.lua:1655
+#: lib/bookshelf_settings.lua:2337
 msgid "Regular"
 msgstr "常规"
 
-#: lib/bookshelf_settings.lua:1655 lib/bookshelf_settings.lua:1656
+#: lib/bookshelf_settings.lua:2337 lib/bookshelf_settings.lua:2338
 msgid "Large"
 msgstr "大"
 
-#: lib/bookshelf_settings.lua:1656
+#: lib/bookshelf_settings.lua:2338
 msgid "Small"
 msgstr "小"
 
-#: lib/bookshelf_settings.lua:1656
+#: lib/bookshelf_settings.lua:2338
 msgid "Medium"
 msgstr "中"
 
-#: lib/bookshelf_settings.lua:1718
+#: lib/bookshelf_settings.lua:2400
 msgid "Book: "
 msgstr "书籍:  "
 
-#: lib/bookshelf_settings.lua:1725
+#: lib/bookshelf_settings.lua:2407
 msgid "Bookshelf: "
 msgstr "书架: "
 
-#: lib/bookshelf_settings.lua:1731
+#: lib/bookshelf_settings.lua:2413
 msgid "Accept"
 msgstr "接受"
 
-#: lib/bookshelf_settings.lua:1783
+#: lib/bookshelf_settings.lua:2465
 msgid "Book detail font scale"
 msgstr "书籍详情字体比例"
 
-#: lib/bookshelf_settings.lua:1846
+#: lib/bookshelf_settings.lua:2528
 msgid "Chip bar font scale"
 msgstr "分类栏字体比例"
 
-#: lib/bookshelf_settings.lua:1910
+#: lib/bookshelf_settings.lua:2592
 msgid "Stack & folder label scale"
 msgstr "堆叠&文件夹标签比例"
 
-#: lib/bookshelf_settings.lua:1978
+#: lib/bookshelf_settings.lua:2660
 msgid "Hero card"
 msgstr "书籍详情卡片"
 
-#: lib/bookshelf_settings.lua:1979
+#: lib/bookshelf_settings.lua:2661
 msgid "Chip bar"
 msgstr "分类栏"
 
-#: lib/bookshelf_settings.lua:1980
+#: lib/bookshelf_settings.lua:2662
 msgid "Stack & folder labels"
 msgstr "堆叠 &文件夹 标签"
 
-#: lib/bookshelf_settings.lua:1981
+#: lib/bookshelf_settings.lua:2663
 msgid "Expanded shelf labels"
 msgstr "扩展书架标签"
 
-#: lib/bookshelf_settings.lua:1982
+#: lib/bookshelf_settings.lua:2664
 msgid "Cover badges"
 msgstr "封面徽章"
 
-#: lib/bookshelf_settings.lua:1999
+#: lib/bookshelf_settings.lua:2681
 msgid "Choose image library folder"
 msgstr "选择图片库文件夹"
 
-#: lib/bookshelf_settings.lua:2025
+#: lib/bookshelf_settings.lua:2707
 msgid "\"Latest\" folder walk depth"
 msgstr "「最新」文件夹遍历深度"
 
-#: lib/bookshelf_settings.lua:2026
+#: lib/bookshelf_settings.lua:2708
 msgid ""
 "How deep to scan your library folder for newly-added books. Higher values "
 "take longer on a cold start."
@@ -1383,15 +1723,15 @@ msgstr ""
 "设置检索新书时，书库目录的递归扫描层级。层级数值越大，首次启动全库检索耗时越"
 "长。"
 
-#: lib/bookshelf_settings.lua:2042
+#: lib/bookshelf_settings.lua:2724
 msgid "MB"
 msgstr "MB"
 
-#: lib/bookshelf_settings.lua:2043
+#: lib/bookshelf_settings.lua:2725
 msgid "Cover cache budget"
 msgstr "封面缓存配额"
 
-#: lib/bookshelf_settings.lua:2044
+#: lib/bookshelf_settings.lua:2726
 msgid ""
 "Memory budget for ready-scaled book covers (MB). Higher = smoother paging "
 "and preloading, more RAM. Default 24 MB."
@@ -1399,47 +1739,47 @@ msgstr ""
 "预缩放封面内存配额 (MB): 数值越高，翻页与预加载越流畅，占用运行内存越多，默"
 "认 24MB。"
 
-#: lib/bookshelf_settings.lua:2178
+#: lib/bookshelf_settings.lua:2860
 msgid "Link copied to clipboard"
 msgstr "链接已复制到剪贴板"
 
-#: lib/bookshelf_settings.lua:2254
+#: lib/bookshelf_settings.lua:2936
 msgid "Notify on wake when update available"
 msgstr "通知可用更新"
 
-#: lib/bookshelf_settings.lua:2273
+#: lib/bookshelf_settings.lua:2955
 msgid "Update available"
 msgstr "更新可用"
 
-#: lib/bookshelf_settings.lua:2276
+#: lib/bookshelf_settings.lua:2958
 msgid "Installed version"
 msgstr "已安装的版本"
 
-#: lib/bookshelf_settings.lua:2282
+#: lib/bookshelf_settings.lua:2964
 msgid "Developer updates"
 msgstr "开发版更新"
 
-#: lib/bookshelf_settings.lua:2298
+#: lib/bookshelf_settings.lua:2980
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: lib/bookshelf_settings.lua:2299
+#: lib/bookshelf_settings.lua:2981
 msgid "Install branch"
 msgstr "安装分支版本"
 
-#: lib/bookshelf_settings.lua:2305
+#: lib/bookshelf_settings.lua:2987
 msgid "Reset to latest stable release"
 msgstr "重置到最新的稳定版本"
 
-#: lib/bookshelf_settings.lua:2316 lib/bookshelf_settings.lua:2319
+#: lib/bookshelf_settings.lua:2998 lib/bookshelf_settings.lua:3001
 msgid "Installed: v"
 msgstr "已安装: v"
 
-#: lib/bookshelf_settings.lua:2359
+#: lib/bookshelf_settings.lua:3041
 msgid "Flexible chip widths"
 msgstr "自适应分类宽度"
 
-#: lib/bookshelf_settings.lua:2360
+#: lib/bookshelf_settings.lua:3042
 msgid ""
 "Off: every chip gets the same width. On: each chip is sized to its label, so "
 "single-icon chips stay narrow and longer text labels get more room. Falls "
@@ -1449,87 +1789,87 @@ msgstr ""
 "字的分类保持窄幅，文字较长的分类自动拓宽。若自适应后整体超出栏宽，自动变回等"
 "宽布局。"
 
-#: lib/bookshelf_settings.lua:2420
+#: lib/bookshelf_settings.lua:3102
 msgid "+ Add new chip"
 msgstr "+ 添加新分类"
 
-#: lib/bookshelf_sort_engine.lua:203
+#: lib/bookshelf_sort_engine.lua:233
 msgid "Filename"
 msgstr "文件名"
 
-#: lib/bookshelf_sort_engine.lua:208
+#: lib/bookshelf_sort_engine.lua:238
 msgid "Author (given name)"
 msgstr "作者 (名字)"
 
-#: lib/bookshelf_sort_engine.lua:210
+#: lib/bookshelf_sort_engine.lua:240
 msgid "Author surname"
 msgstr "作者姓氏"
 
-#: lib/bookshelf_sort_engine.lua:212
+#: lib/bookshelf_sort_engine.lua:242
 msgid "Series name"
 msgstr "系列名称"
 
-#: lib/bookshelf_sort_engine.lua:215
+#: lib/bookshelf_sort_engine.lua:245
 msgid "Series index"
 msgstr "系列编号"
 
-#: lib/bookshelf_sort_engine.lua:215
+#: lib/bookshelf_sort_engine.lua:245
 msgid "Series #"
 msgstr "系列 #"
 
-#: lib/bookshelf_sort_engine.lua:223
+#: lib/bookshelf_sort_engine.lua:253
 msgid "Series + index"
 msgstr "系列 + 编号"
 
-#: lib/bookshelf_sort_engine.lua:223
+#: lib/bookshelf_sort_engine.lua:253
 msgid "Series + #"
 msgstr "系列 + #"
 
-#: lib/bookshelf_sort_engine.lua:234
+#: lib/bookshelf_sort_engine.lua:264
 msgid "Last opened"
 msgstr "最近打开"
 
-#: lib/bookshelf_sort_engine.lua:234
+#: lib/bookshelf_sort_engine.lua:264
 msgid "Opened"
 msgstr "已打开"
 
-#: lib/bookshelf_sort_engine.lua:240
+#: lib/bookshelf_sort_engine.lua:270
 msgid "Percent read"
 msgstr "阅读进度"
 
-#: lib/bookshelf_sort_engine.lua:245
+#: lib/bookshelf_sort_engine.lua:275
 msgid "Unread/Reading/Finished"
 msgstr "未读/在读/读完"
 
-#: lib/bookshelf_sort_engine.lua:246
+#: lib/bookshelf_sort_engine.lua:276
 msgid "Unread 1st"
 msgstr "未读优先"
 
-#: lib/bookshelf_sort_engine.lua:255
+#: lib/bookshelf_sort_engine.lua:285
 msgid "Reading/Unread/Finished"
 msgstr "在读/未读/已读"
 
-#: lib/bookshelf_sort_engine.lua:256
+#: lib/bookshelf_sort_engine.lua:286
 msgid "Reading 1st"
 msgstr "在读优先"
 
-#: lib/bookshelf_sort_engine.lua:267
+#: lib/bookshelf_sort_engine.lua:297
 msgid "Date added"
 msgstr "添加日期"
 
-#: lib/bookshelf_sort_engine.lua:267 lib/bookshelf_widget.lua:6476
+#: lib/bookshelf_sort_engine.lua:297 lib/bookshelf_widget.lua:6713
 msgid "Added"
 msgstr "已添加"
 
-#: lib/bookshelf_sort_engine.lua:279
+#: lib/bookshelf_sort_engine.lua:309
 msgid "File size"
 msgstr "文件大小"
 
-#: lib/bookshelf_sort_engine.lua:301
+#: lib/bookshelf_sort_engine.lua:331
 msgid "Page count"
 msgstr "总页数"
 
-#: lib/bookshelf_sort_engine.lua:301
+#: lib/bookshelf_sort_engine.lua:331
 msgid "Pages"
 msgstr "页数"
 
@@ -1545,7 +1885,7 @@ msgstr "在读"
 msgid "Latest"
 msgstr "新书"
 
-#: lib/bookshelf_tab_model.lua:56 lib/bookshelf_widget.lua:1066
+#: lib/bookshelf_tab_model.lua:56 lib/bookshelf_widget.lua:1165
 msgid "Tags"
 msgstr "标签"
 
@@ -1633,191 +1973,315 @@ msgstr "无法获取最新版本。"
 msgid "Latest release has no downloadable zip."
 msgstr "最新发布版本没有可下载的压缩包。"
 
-#: lib/bookshelf_widget.lua:1274
+#: lib/bookshelf_widget.lua:1373
 #, lua-format
 msgid "No matches for \"%s\""
 msgstr "无法匹配 「%s」"
 
-#: lib/bookshelf_widget.lua:1276
+#: lib/bookshelf_widget.lua:1375
 msgid ""
 "Nothing in Series yet · Add series metadata to your books and they will "
 "appear here"
 msgstr "尚无「系列」分类 · 将系列元数据添加到你的书籍中，它们就会显示在这里"
 
-#: lib/bookshelf_widget.lua:1278
+#: lib/bookshelf_widget.lua:1377
 msgid ""
 "No authors yet · Add author metadata to your books and they will appear here"
 msgstr "尚无「作者」分类 · 将作者元数据添加到你的书籍中，它们就会显示在这里"
 
-#: lib/bookshelf_widget.lua:1280
+#: lib/bookshelf_widget.lua:1379
 msgid ""
 "No genres yet · Add keywords or subject metadata to your books and they will "
 "appear here"
 msgstr "尚无「题材」分类 · 将题材元数据添加到你的书籍中，它们就会显示在这里"
 
-#: lib/bookshelf_widget.lua:1282
+#: lib/bookshelf_widget.lua:1381
 msgid ""
 "No collections yet · Long-press a book and tap 'Collections…' to create one"
 msgstr "尚无「书单」分类 · 长按一本书，点击「书单…」创造一个"
 
-#: lib/bookshelf_widget.lua:1284
+#: lib/bookshelf_widget.lua:1383
 msgid "No favourites yet · Long-press a book and tap 'Add to favourites'"
 msgstr "尚无「收藏」分类 · 长按一本书，点击「收藏…」"
 
-#: lib/bookshelf_widget.lua:1286
+#: lib/bookshelf_widget.lua:1385
 msgid "No books found · Set your library folder in Settings then tap Latest"
 msgstr "未检索到书籍 · 前往设置配置书库文件夹后，点击「新近入库」"
 
-#: lib/bookshelf_widget.lua:1288
+#: lib/bookshelf_widget.lua:1387
 msgid "No recent reads yet · Open a book and it will appear here"
 msgstr "尚无在读 · 打开一本书，它会出现在这里"
 
-#: lib/bookshelf_widget.lua:1294
+#: lib/bookshelf_widget.lua:1393
 msgid ""
 "No books here yet · Pick a folder to use as your KOReader library and books "
 "in it will appear here."
 msgstr ""
 "这里还没有书 · 选择一个文件夹作为你的KOReader书库，里面的书籍会显示在这里。"
 
-#: lib/bookshelf_widget.lua:1304
+#: lib/bookshelf_widget.lua:1403
 #, lua-format
 msgid "No books in %s yet · Long-press the chip to edit its source or filter"
 msgstr "尚无书籍在「%s」 · 长按分类以编辑其来源或过滤"
 
-#: lib/bookshelf_widget.lua:1307
+#: lib/bookshelf_widget.lua:1406
 #, lua-format
 msgid "No books in %s yet"
 msgstr "尚无书籍在「%s」"
 
-#: lib/bookshelf_widget.lua:1319
+#: lib/bookshelf_widget.lua:1418
 #, lua-format
 msgid "Nothing in %s yet · Long-press the chip to edit its filter"
 msgstr "「%s」里什么也没有 · 长按分类以编辑其过滤"
 
-#: lib/bookshelf_widget.lua:1403
+#: lib/bookshelf_widget.lua:1502
 msgid "Set home folder"
 msgstr "设置主页文件夹"
 
-#: lib/bookshelf_widget.lua:1412
+#: lib/bookshelf_widget.lua:1511
 msgid "Current home folder:"
 msgstr "当前主页文件夹:"
 
-#: lib/bookshelf_widget.lua:2476 lib/bookshelf_widget.lua:7298
+#: lib/bookshelf_widget.lua:2575 lib/bookshelf_widget.lua:7945
 msgid "File no longer exists. The bookshelf entry is stale."
 msgstr "文件已不存在，书架条目失效。"
 
-#: lib/bookshelf_widget.lua:3149 lib/bookshelf_widget.lua:4845
+#: lib/bookshelf_widget.lua:3322 lib/bookshelf_widget.lua:5042
 msgid "Selection cleared"
 msgstr "已取消选中"
 
-#: lib/bookshelf_widget.lua:3315
+#: lib/bookshelf_widget.lua:3488
 #, lua-format
 msgid "No items start with %q"
 msgstr "没有以 %q 开头的项目"
 
-#: lib/bookshelf_widget.lua:3331
+#: lib/bookshelf_widget.lua:3504
 msgid "Enter text, letter or page number"
 msgstr "输入文本、字母或页码"
 
-#: lib/bookshelf_widget.lua:3333
+#: lib/bookshelf_widget.lua:3510
 #, lua-format
 msgid "(a - z) or (1 - %d)"
 msgstr "(a - z) 或 (1 - %d)"
 
-#: lib/bookshelf_widget.lua:3349
+#: lib/bookshelf_widget.lua:3526
 msgid "Go to letter"
 msgstr "跳转到首字母"
 
-#: lib/bookshelf_widget.lua:3370
+#: lib/bookshelf_widget.lua:3547
 msgid "Go to page"
 msgstr "跳转页码"
 
-#: lib/bookshelf_widget.lua:3376
+#: lib/bookshelf_widget.lua:3553
 #, lua-format
 msgid "Page must be between 1 and %d"
 msgstr "页码需在 1～%d 区间内"
 
-#: lib/bookshelf_widget.lua:6225
+#: lib/bookshelf_widget.lua:6421
 msgid "Refreshing library…"
 msgstr "正在刷新书库…"
 
-#: lib/bookshelf_widget.lua:6277
+#: lib/bookshelf_widget.lua:6473
 msgid "✓ Bookshelf is my home screen"
 msgstr "✓ 「Bookshelf」设为主屏幕"
 
-#: lib/bookshelf_widget.lua:6278
+#: lib/bookshelf_widget.lua:6474
 msgid "Set as home screen"
 msgstr "设置为主屏幕"
 
-#: lib/bookshelf_widget.lua:6285 lib/bookshelf_widget.lua:6289
+#: lib/bookshelf_widget.lua:6481 lib/bookshelf_widget.lua:6485
 msgid "Bookshelf will load on next launch"
 msgstr "「Bookshelf」将在下次启动时加载"
 
-#: lib/bookshelf_widget.lua:6422
+#: lib/bookshelf_widget.lua:6659
 msgid "(no title)"
 msgstr "(无标题)"
 
-#: lib/bookshelf_widget.lua:6478
+#: lib/bookshelf_widget.lua:6715
 msgid "Read"
 msgstr "已读"
 
-#: lib/bookshelf_widget.lua:7139
-msgid "Description"
-msgstr "描述"
+#: lib/bookshelf_widget.lua:7431
+msgid "No Hardcover book is linked yet."
+msgstr "暂无已关联 Hardcover 的书籍。"
 
-#: lib/bookshelf_widget.lua:7477
+#: lib/bookshelf_widget.lua:7452
+msgid "Hardcover spoiler-free reviews"
+msgstr "Hardcover 无剧透书评"
+
+#: lib/bookshelf_widget.lua:7480
+msgid "Fetching Hardcover reviews..."
+msgstr "正在获取 Hardcover 书评…"
+
+#: lib/bookshelf_widget.lua:7488
+msgid "Hardcover reviews could not be fetched: "
+msgstr "无法获取 Hardcover 书评："
+
+#: lib/bookshelf_widget.lua:7602
+msgid "Hardcover metadata refreshed"
+msgstr "Hardcover 元数据已刷新"
+
+#: lib/bookshelf_widget.lua:7604
+msgid "Hardcover refresh failed"
+msgstr "Hardcover 刷新失败"
+
+#: lib/bookshelf_widget.lua:7616
+msgid "Auto link"
+msgstr "自动关联"
+
+#: lib/bookshelf_widget.lua:7616
+msgid "Auto link (best guess)"
+msgstr "自动关联（智能匹配）"
+
+#: lib/bookshelf_widget.lua:7621
+msgid "No embedded Hardcover identifier found"
+msgstr "未检测到内嵌的 Hardcover 标识"
+
+#: lib/bookshelf_widget.lua:7624 lib/bookshelf_widget.lua:7659
+msgid "Hardcover book linked"
+msgstr "已关联 Hardcover 书籍"
+
+#: lib/bookshelf_widget.lua:7631
+msgid "No confident Hardcover match -- try Manual link"
+msgstr "未找到高匹配度的 Hardcover 书籍，请尝试手动关联"
+
+#: lib/bookshelf_widget.lua:7632 lib/bookshelf_widget.lua:7666
+msgid "Hardcover search failed"
+msgstr "Hardcover 搜索失败"
+
+#: lib/bookshelf_widget.lua:7636
+msgid "Hardcover book linked (best guess)"
+msgstr "已关联 Hardcover 书籍（智能匹配）"
+
+#: lib/bookshelf_widget.lua:7643
+msgid "Manual link"
+msgstr "手动关联"
+
+#: lib/bookshelf_widget.lua:7651 lib/bookshelf_widget.lua:7685
+msgid "Hardcover link failed"
+msgstr "Hardcover 关联失败"
+
+#: lib/bookshelf_widget.lua:7656
+msgid "Book linked, but metadata refresh failed: %1"
+msgstr "书籍已关联，但元数据刷新失败：%1"
+
+#: lib/bookshelf_widget.lua:7673
+msgid "Select edition"
+msgstr "选择版本"
+
+#: lib/bookshelf_widget.lua:7678
+msgid "Link a Hardcover book first"
+msgstr "请先关联 Hardcover 书籍"
+
+#: lib/bookshelf_widget.lua:7690
+msgid "Edition linked, but metadata refresh failed: %1"
+msgstr "版本已关联，但元数据刷新失败：%1"
+
+#: lib/bookshelf_widget.lua:7693
+msgid "Hardcover edition linked"
+msgstr "已关联 Hardcover 版本"
+
+#: lib/bookshelf_widget.lua:7698
+msgid "Hardcover edition search failed"
+msgstr "Hardcover 版本搜索失败"
+
+#: lib/bookshelf_widget.lua:7705
+msgid "Clear link"
+msgstr "清除关联"
+
+#: lib/bookshelf_widget.lua:7711
+msgid "Hardcover link cleared"
+msgstr "Hardcover 关联已清除"
+
+#: lib/bookshelf_widget.lua:7713
+msgid "Could not clear Hardcover link"
+msgstr "无法清除 Hardcover  关联"
+
+#: lib/bookshelf_widget.lua:7739
+msgid "Use Hardcover image"
+msgstr "使用 Hardcover 图片"
+
+#: lib/bookshelf_widget.lua:7749
+msgid "Could not update"
+msgstr "无法更新"
+
+#: lib/bookshelf_widget.lua:7766
+msgid "Use Hardcover description"
+msgstr "使用 Hardcover 简介"
+
+#: lib/bookshelf_widget.lua:7784
+msgid "Linked: %1"
+msgstr "已关联: %1"
+
+#: lib/bookshelf_widget.lua:7785
+msgid "Not linked to Hardcover"
+msgstr "未关联 Hardcover"
+
+#: lib/bookshelf_widget.lua:7793
+msgid "Hardcover"
+msgstr "Hardcover"
+
+#: lib/bookshelf_widget.lua:8131
 msgid "Metadata refresh queued"
 msgstr "元数据刷新队列"
 
-#: lib/bookshelf_widget.lua:7716
+#: lib/bookshelf_widget.lua:8167
+msgid "Edit Hardcover link"
+msgstr "编辑 Hardcover 关联"
+
+#: lib/bookshelf_widget.lua:8169
+msgid "Link to Hardcover"
+msgstr "关联到 Hardcove"
+
+#: lib/bookshelf_widget.lua:8424
 msgid "Delete file permanently?"
 msgstr "永久删除文件？"
 
-#: lib/bookshelf_widget.lua:7729
+#: lib/bookshelf_widget.lua:8437
 msgid "Failed to delete file."
 msgstr "删除文件失败。"
 
-#: lib/bookshelf_widget.lua:7761
+#: lib/bookshelf_widget.lua:8469
 msgid "Select"
 msgstr "选择"
 
-#: lib/bookshelf_widget.lua:7793
+#: lib/bookshelf_widget.lua:8501
 msgid "File no longer exists."
 msgstr "文件已不存在。"
 
-#: lib/bookshelf_widget.lua:8171
+#: lib/bookshelf_widget.lua:8888
 msgid "this folder"
 msgstr "这个文件夹"
 
-#: lib/bookshelf_widget.lua:8172
+#: lib/bookshelf_widget.lua:8889
 msgid "this series"
 msgstr "这个系列"
 
-#: lib/bookshelf_widget.lua:8173
+#: lib/bookshelf_widget.lua:8890
 msgid "this author"
 msgstr "这个作者"
 
-#: lib/bookshelf_widget.lua:8174
+#: lib/bookshelf_widget.lua:8891
 msgid "this genre"
 msgstr "这个题材"
 
-#: lib/bookshelf_widget.lua:8175
+#: lib/bookshelf_widget.lua:8892
 msgid "this collection"
 msgstr "这个书单"
 
-#: lib/bookshelf_widget.lua:8176
+#: lib/bookshelf_widget.lua:8893
 msgid "this format"
 msgstr "这个格式"
 
-#: lib/bookshelf_widget.lua:8177
+#: lib/bookshelf_widget.lua:8894
 msgid "this rating"
 msgstr "这个评分"
 
-#: lib/bookshelf_widget.lua:8178
+#: lib/bookshelf_widget.lua:8895
 msgid "this group"
 msgstr "这个分组"
 
-#: lib/bookshelf_widget.lua:8200
+#: lib/bookshelf_widget.lua:8917
 #, lua-format
 msgid ""
 "Pin %s to the chip bar for quick access,\n"
@@ -1826,7 +2290,7 @@ msgstr ""
 "将「%s」固定到分类栏上以便快速访问，\n"
 "或者将 %d 本书从你的选择中移除。"
 
-#: lib/bookshelf_widget.lua:8206
+#: lib/bookshelf_widget.lua:8923
 #, lua-format
 msgid ""
 "Pin %s to the chip bar for quick access,\n"
@@ -1835,7 +2299,7 @@ msgstr ""
 "将「%s」固定到分类栏上以便快速访问，\n"
 "或者可再新增 %d 个 / 移除已选中的 %d 个。"
 
-#: lib/bookshelf_widget.lua:8210
+#: lib/bookshelf_widget.lua:8927
 #, lua-format
 msgid ""
 "Pin %s to the chip bar for quick access,\n"
@@ -1844,72 +2308,75 @@ msgstr ""
 "将「%s」固定到分类栏上以便快速访问，\n"
 "或将其下 %d 本图书加入选中列表以批量编辑。"
 
-#: lib/bookshelf_widget.lua:8285
+#: lib/bookshelf_widget.lua:9002
 msgid "Pin"
 msgstr "固定"
 
-#: lib/bookshelf_widget.lua:8300 lib/bookshelf_widget.lua:8301
+#: lib/bookshelf_widget.lua:9017 lib/bookshelf_widget.lua:9018
 #, lua-format
 msgid "Add %d"
 msgstr "添加 %d 个"
 
-#: lib/bookshelf_widget.lua:8310
+#: lib/bookshelf_widget.lua:9027
 #, lua-format
 msgid "Remove %d"
 msgstr "删除 %d 个"
 
-#: lib/bookshelf_widget.lua:8330
+#: lib/bookshelf_widget.lua:9047
 msgid "Set folder image…"
 msgstr "设置文件夹图片…"
 
-#: lib/bookshelf_widget.lua:8337
+#: lib/bookshelf_widget.lua:9054
 msgid "Clear folder image"
 msgstr "清除文件夹图片"
 
-#: lib/bookshelf_widget.lua:8357 lib/bookshelf_widget.lua:8368
+#: lib/bookshelf_widget.lua:9074 lib/bookshelf_widget.lua:9085
 msgid "Set author image…"
 msgstr "设置作者图片…"
 
-#: lib/bookshelf_widget.lua:8358 lib/bookshelf_widget.lua:8369
+#: lib/bookshelf_widget.lua:9075 lib/bookshelf_widget.lua:9086
 msgid "Set series image…"
 msgstr "设置系列图片…"
 
-#: lib/bookshelf_widget.lua:8359 lib/bookshelf_widget.lua:8370
+#: lib/bookshelf_widget.lua:9076 lib/bookshelf_widget.lua:9087
 msgid "Set genre image…"
 msgstr "设定题材图片…"
 
-#: lib/bookshelf_widget.lua:8360 lib/bookshelf_widget.lua:8371
+#: lib/bookshelf_widget.lua:9077 lib/bookshelf_widget.lua:9088
 msgid "Set collection image…"
 msgstr "设置书单图片…"
 
-#: lib/bookshelf_widget.lua:8361 lib/bookshelf_widget.lua:8374
+#: lib/bookshelf_widget.lua:9078 lib/bookshelf_widget.lua:9091
 msgid "Clear author image"
 msgstr "清除作者图片"
 
-#: lib/bookshelf_widget.lua:8362 lib/bookshelf_widget.lua:8375
+#: lib/bookshelf_widget.lua:9079 lib/bookshelf_widget.lua:9092
 msgid "Clear series image"
 msgstr "清除系列图片"
 
-#: lib/bookshelf_widget.lua:8363 lib/bookshelf_widget.lua:8376
+#: lib/bookshelf_widget.lua:9080 lib/bookshelf_widget.lua:9093
 msgid "Clear genre image"
 msgstr "清除题材图片"
 
-#: lib/bookshelf_widget.lua:8364 lib/bookshelf_widget.lua:8377
+#: lib/bookshelf_widget.lua:9081 lib/bookshelf_widget.lua:9094
 msgid "Clear collection image"
 msgstr "清除书单图片"
 
-#: lib/bookshelf_widget.lua:8445
+#: lib/bookshelf_widget.lua:9162
 msgid "Choose folder image"
 msgstr "选择文件夹图片"
 
-#: lib/bookshelf_widget.lua:8484
+#: lib/bookshelf_widget.lua:9201
 msgid "Choose image"
 msgstr "选择图像"
 
-#: lib/bookshelf_widget.lua:8696
+#: lib/bookshelf_widget.lua:9460
 msgid "Search library"
 msgstr "搜索库"
 
-#: lib/bookshelf_widget.lua:8698
+#: lib/bookshelf_widget.lua:9462
 msgid "title, author, series, genre…"
 msgstr "标题，作者，系列，题材…"
+
+#~ msgid "Badge font scale"
+#~ msgstr "徽章字体比例"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-05-31 19:26+0100\n"
-"PO-Revision-Date: 2026-06-06 00:24+0800\n"
+"PO-Revision-Date: 2026-06-06 01:40+0800\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: zh_CN\n"
@@ -51,15 +51,15 @@ msgstr "关闭 Bookshelf"
 
 #: main.lua:440
 msgid "Open Bookshelf"
-msgstr "启用 Bookshelf"
+msgstr "开启 Bookshelf"
 
 #: main.lua:484
 msgid "Edit book detail view"
-msgstr "编辑图书详情页"
+msgstr "编辑图书详情"
 
 #: main.lua:493
 msgid "Bookshelf chips…"
-msgstr "Bookshelf分类…"
+msgstr "书架分类…"
 
 #: main.lua:501
 msgid "Manage collections…"
@@ -107,7 +107,7 @@ msgstr "Bookshelf: 上一个分类"
 
 #: main.lua:726
 msgid "Bookshelf: expand or collapse hero"
-msgstr "Bookshelf: 展开/折叠 头图"
+msgstr "Bookshelf: 展开/折叠 书籍详情"
 
 #: main.lua:732
 msgid "Bookshelf: toggle selection mode"
@@ -170,15 +170,15 @@ msgid ""
 "Install the CoverBrowser plugin to enable it."
 msgstr ""
 "图书元数据扫描器不可用。\n"
-"安装CoverBrowser插件以启用它。"
+"安装 CoverBrowser 插件以启用它。"
 
 #: main.lua:1275
 msgid ""
 "This will clear the development branch setting and install the latest stable "
 "release of Bookshelf, then restart KOReader. Continue?"
 msgstr ""
-"这样可以清除开发分支设置，安装最新的Bookshelf稳定版本，之后会重启KOReader。是"
-"否继续？"
+"这样可以清除开发分支设置，安装最新的 Bookshelf 稳定发布版本，之后会重启 "
+"KOReader。是否继续？"
 
 #: main.lua:1276 lib/bookshelf_bulk_actions.lua:284
 #: lib/bookshelf_settings.lua:1450 lib/bookshelf_settings.lua:1493
@@ -187,7 +187,7 @@ msgstr "重置"
 
 #: main.lua:1297
 msgid "Bookshelf update available: v"
-msgstr "Bookshelf 可更新: v"
+msgstr "「Bookshelf」可更新: v"
 
 #: lib/bookshelf_bulk_actions.lua:25
 #, lua-format
@@ -233,7 +233,7 @@ msgstr "设定评分"
 #: lib/bookshelf_bulk_actions.lua:183 lib/bookshelf_bulk_actions.lua:185
 #: lib/bookshelf_bulk_actions.lua:187 lib/bookshelf_widget.lua:7349
 msgid "Favourite"
-msgstr "收藏夹"
+msgstr "收藏"
 
 #: lib/bookshelf_bulk_actions.lua:213 lib/bookshelf_chip_editor.lua:197
 #: lib/bookshelf_chip_editor.lua:1203 lib/bookshelf_widget.lua:7383
@@ -337,7 +337,7 @@ msgstr "首页 (平铺)"
 
 #: lib/bookshelf_chip_editor.lua:192 lib/bookshelf_chip_editor.lua:1172
 msgid "Recently read"
-msgstr "最近阅读"
+msgstr "在读"
 
 #: lib/bookshelf_chip_editor.lua:193 lib/bookshelf_chip_editor.lua:1173
 msgid "Latest added"
@@ -775,7 +775,7 @@ msgstr "图标…"
 
 #: lib/bookshelf_library_modal.lua:856
 msgid "Page %1 of %2"
-msgstr "%1 / %2 页"
+msgstr "第 %1 / %2 页"
 
 #: lib/bookshelf_picker_cell.lua:90
 msgid "book"
@@ -827,7 +827,7 @@ msgid ""
 "  [if:series]Book %series_num of %series_name[/if]\n"
 "  [if:batt<20]LOW %batt[/if]"
 msgstr ""
-"占位符用于在渲染图书详情页、状态栏时自动替换为实时数据。\n"
+"占位符用于在渲染图书详情、状态栏时自动替换为实时数据。\n"
 "\n"
 "  %title — %book_pct\n"
 "  → 沙丘 — 36%\n"
@@ -1062,8 +1062,8 @@ msgid ""
 "hero size with the bookshelf visible behind it. Changes preview in realtime; "
 "Accept keeps them, Cancel reverts."
 msgstr ""
-"弹出小型悬浮面板，可在书架页面可见状态下循环切换封面尺寸与头图尺寸。修改实时"
-"预览，点击确认保存设置、点击撤销恢复原有参数。"
+"弹出小型悬浮面板，可在书架页面可见状态下循环切换封面尺寸与书籍详情尺寸。修改"
+"实时预览，点击确认保存设置、点击撤销恢复原有参数。"
 
 #: lib/bookshelf_settings.lua:1106
 msgid "Cover display"
@@ -1131,7 +1131,7 @@ msgstr ""
 
 #: lib/bookshelf_settings.lua:1319
 msgid "\"Latest\" walk depth"
-msgstr "「最新」目录遍历深度"
+msgstr "新书遍历深度"
 
 #: lib/bookshelf_settings.lua:1324
 msgid "Cover cache"
@@ -1197,10 +1197,10 @@ msgid ""
 "-- tap stages the book as the hero preview, tap the hero opens it -- and are "
 "unaffected by this setting."
 msgstr ""
-"开启后，在头图卡片或展开模式的书架封面处打开书籍需要双击操作：首次点击选中封"
-"面 (出现选中高亮框)，再次点击才启动书本。适合浏览时容易误点开图书的用户。常规"
-"书架封面 (显示头部大图) 本身已是该交互逻辑：单击将图书设为头图预览，点击头图"
-"打开书籍，不受本选项控制。"
+"开启后，在书籍详情卡片或展开模式的书架封面处打开书籍需要双击操作：首次点击选"
+"中封面 (出现选中高亮框)，再次点击才启动书本。适合浏览时容易误点开图书的用户。"
+"常规书架封面 (显示头部大图) 本身已是该交互逻辑：单击将图书设为书籍详情预览，"
+"点击书籍详情打开书籍，不受本选项控制。"
 
 #: lib/bookshelf_settings.lua:1401
 msgid "Closing book notification"
@@ -1224,7 +1224,7 @@ msgstr "跟随 KOReader 设置"
 
 #: lib/bookshelf_settings.lua:1424
 msgid "Bookshelf UI font: %1"
-msgstr "Bookshelf 界面字体: %1"
+msgstr "书架界面字体: %1"
 
 #: lib/bookshelf_settings.lua:1426
 msgid ""
@@ -1233,9 +1233,9 @@ msgid ""
 "KOReader UI font. The hero title and author have their own fonts in the hero "
 "card editor."
 msgstr ""
-"书架界面文字 (分类、标签、元数据)所用字体，可任选已安装字体 (选择器与头图卡片"
-"相同)；'(默认)' 选项同步 KOReader 全局界面字体。头图的书名、作者字体需在头图"
-"卡片编辑面板单独设置。"
+"书架界面文字 (分类、标签、元数据) 所用字体，可任选已安装字体 (选择器与书籍详"
+"情卡片相同)；'(默认)' 选项同步 KOReader 全局界面字体。书籍详情的书名、作者字"
+"体需在书籍详情卡片编辑面板单独设置。"
 
 #: lib/bookshelf_settings.lua:1434
 msgid "Reset chip bar to defaults"
@@ -1251,8 +1251,8 @@ msgid ""
 "unaffected."
 msgstr ""
 "清空自定义标签布局 (包含标签显示项、排序顺序、名称图标、来源、筛选及排序规"
-"则)，恢复软件初始默认标签配置: 首页、最新入库、丛书、收藏设为启用状态，其余标"
-"签可手动开启。同时将当前选中标签切回首页、页码重置为 1。头图文字、字体、配色"
+"则)，恢复软件初始默认标签配置: 首页、新书、丛书、收藏设为启用状态，其余标签可"
+"手动开启。同时将当前选中标签切回首页、页码重置为 1。书籍详情文字、字体、配色"
 "等其他设置保持不变。"
 
 #: lib/bookshelf_settings.lua:1446
@@ -1264,8 +1264,8 @@ msgid ""
 msgstr ""
 "是否将分类栏恢复默认设置？\n"
 "\n"
-"所有自行新增、修改的自定义分类将会被清除；书架其余配置 (头图文字、字体、配色)"
-"保持不变。"
+"所有自行新增、修改的自定义分类将会被清除；书架其余配置 (书籍详情文字、字体、"
+"配色)保持不变。"
 
 #: lib/bookshelf_settings.lua:1482
 msgid "Reset book detail area to defaults"
@@ -1277,7 +1277,7 @@ msgid ""
 "detail layout, including the bundled title (Inter ExtraBold) and author "
 "(Caveat) fonts. The Bookshelf UI font and chip bar are unaffected."
 msgstr ""
-"清除头图与书籍详情页的自定义样式，恢复出厂默认排版，标题字体 (Inter "
+"清除书籍详情与书籍详情页的自定义样式，恢复出厂默认排版，标题字体 (Inter "
 "ExtraBold)、作者字体 (Caveat)一并还原为预设样式。书架界面字体、顶部贴片栏配置"
 "不受改动。"
 
@@ -1290,8 +1290,7 @@ msgid ""
 msgstr ""
 "是否重置书籍详情区域为默认配置？\n"
 "\n"
-"所有头图与详情页的文字、字体自定义设置将会清空；书架界面字体、顶部贴片栏保持"
-"不变。"
+"所有书籍详情的文字、字体自定义设置将会清空；书架界面字体、分类栏保持不变。"
 
 #: lib/bookshelf_settings.lua:1508
 msgid "BETA: Read calibre metadata.calibre"
@@ -1346,11 +1345,11 @@ msgstr "分类栏字体比例"
 
 #: lib/bookshelf_settings.lua:1910
 msgid "Stack & folder label scale"
-msgstr "堆叠 &文件夹 标签比例"
+msgstr "堆叠&文件夹标签比例"
 
 #: lib/bookshelf_settings.lua:1978
 msgid "Hero card"
-msgstr "头图卡片"
+msgstr "书籍详情卡片"
 
 #: lib/bookshelf_settings.lua:1979
 msgid "Chip bar"
@@ -1430,11 +1429,11 @@ msgstr "安装分支版本"
 
 #: lib/bookshelf_settings.lua:2305
 msgid "Reset to latest stable release"
-msgstr "重置到最新稳定版本"
+msgstr "重置到最新的稳定版本"
 
 #: lib/bookshelf_settings.lua:2316 lib/bookshelf_settings.lua:2319
 msgid "Installed: v"
-msgstr "安装: v"
+msgstr "已安装: v"
 
 #: lib/bookshelf_settings.lua:2359
 msgid "Flexible chip widths"
@@ -1476,15 +1475,15 @@ msgstr "系列编号"
 
 #: lib/bookshelf_sort_engine.lua:215
 msgid "Series #"
-msgstr "系列#"
+msgstr "系列 #"
 
 #: lib/bookshelf_sort_engine.lua:223
 msgid "Series + index"
-msgstr "系列+编号"
+msgstr "系列 + 编号"
 
 #: lib/bookshelf_sort_engine.lua:223
 msgid "Series + #"
-msgstr "系列 +#"
+msgstr "系列 + #"
 
 #: lib/bookshelf_sort_engine.lua:234
 msgid "Last opened"
@@ -1540,11 +1539,11 @@ msgstr "首页"
 
 #: lib/bookshelf_tab_model.lua:46
 msgid "Recent"
-msgstr "最近阅读"
+msgstr "在读"
 
 #: lib/bookshelf_tab_model.lua:48
 msgid "Latest"
-msgstr "最新入库"
+msgstr "新书"
 
 #: lib/bookshelf_tab_model.lua:56 lib/bookshelf_widget.lua:1066
 msgid "Tags"
@@ -1568,7 +1567,7 @@ msgstr "无法查看更新。"
 
 #: lib/bookshelf_updater.lua:238
 msgid "Bookshelf is up to date."
-msgstr "Bookshelf 已是最新版本。"
+msgstr "「Bookshelf」已是最新版本。"
 
 #: lib/bookshelf_updater.lua:239
 msgid "Version: "
@@ -1608,11 +1607,11 @@ msgstr "安装失败: "
 
 #: lib/bookshelf_updater.lua:398
 msgid "Bookshelf updated to v"
-msgstr "Bookshelf更新到 v"
+msgstr "「Bookshelf」更新到 v"
 
 #: lib/bookshelf_updater.lua:399
 msgid "Restart KOReader now?"
-msgstr "现在重启KOReader？"
+msgstr "现在重启「KOReader」？"
 
 #: lib/bookshelf_updater.lua:400
 msgid "Restart"
@@ -1705,7 +1704,7 @@ msgstr "当前主页文件夹:"
 
 #: lib/bookshelf_widget.lua:2476 lib/bookshelf_widget.lua:7298
 msgid "File no longer exists. The bookshelf entry is stale."
-msgstr "文件已不存在，Bookshelf 条目失效。"
+msgstr "文件已不存在，书架条目失效。"
 
 #: lib/bookshelf_widget.lua:3149 lib/bookshelf_widget.lua:4845
 msgid "Selection cleared"
@@ -1744,7 +1743,7 @@ msgstr "正在刷新书库…"
 
 #: lib/bookshelf_widget.lua:6277
 msgid "✓ Bookshelf is my home screen"
-msgstr "✓ Bookshelf 设为主屏幕"
+msgstr "✓ 「Bookshelf」设为主屏幕"
 
 #: lib/bookshelf_widget.lua:6278
 msgid "Set as home screen"
@@ -1752,7 +1751,7 @@ msgstr "设置为主屏幕"
 
 #: lib/bookshelf_widget.lua:6285 lib/bookshelf_widget.lua:6289
 msgid "Bookshelf will load on next launch"
-msgstr "Bookshelf 将在下次启动时加载"
+msgstr "「Bookshelf」将在下次启动时加载"
 
 #: lib/bookshelf_widget.lua:6422
 msgid "(no title)"


### PR DESCRIPTION
Add all Chinese translations in `bookshelf.pot`.
Maybe there is a translation that is not appropriate enough, I will update it later.

#### Known issues:
 - The 'Status line:' from the Settings is also not in the list.
 - Several texts related to 'Bar' were not found in the UI, and the English 'bar' was left untranslated because of its ambiguous meaning:
   - `Bar: `
   - `- Bar`
   - `+ Bar`
   - `Bar height`