### PR TITLE
Fix: On This Day shows stale events after midnight

### DIFF
--- a/micromodules/on_this_day.lua
+++ b/micromodules/on_this_day.lua
@@ -110,7 +110,10 @@ local function maybeScheduleImplicitFetch()
         fetchOTD(false, function(result)
             _implicit_fetch_pending = false
             if result then
-                UIManager:setDirty(nil, "ui")
+                local StartMenu = require("lib/bookshelf_start_menu")
+                if StartMenu._live and StartMenu._live._reload then
+                    StartMenu._live:_reload()
+                end
             end
         end)
     end)
@@ -166,6 +169,18 @@ return {
         end
 
         local data = Store.read(KEY_DATA)
+
+        -- Invalidate stale cache from a previous day
+        local current_day = os.date("%Y-%m-%d")
+        local cached_day = Store.read(KEY_DAY, "")
+        if data and current_day ~= cached_day then
+            data = nil
+            Store.save(KEY_DATA, nil)
+            _pages_cache = nil
+            _total_pages = 1
+            _view_index = 1
+        end
+
         if data and #data > 10 then
             local limited = {}
             for i = 1, 10 do table.insert(limited, data[i]) end


### PR DESCRIPTION
## Problem

The **On This Day** module displays yesterday's cached events after midnight instead of fetching today's events. This is the typical scenario on e-readers that stay in standby overnight.

### Root cause

Two issues work together to cause this:

1. **`render()` never checks if the cached day matches today.** It reads `KEY_DATA` and, if data exists, displays it directly — without comparing `KEY_DAY` against the current date. The day check exists inside `fetchOTD()`, but `render()` only calls `maybeScheduleImplicitFetch()` when data is `nil` or empty. Stale data from the previous day is always shown.

2. **`maybeScheduleImplicitFetch()` uses `UIManager:setDirty(nil, "ui")`**, which marks the screen as dirty but does **not** rebuild the Start Menu card widget tree. As a result, even when a fresh fetch completes, the card stays stuck on "Fetching..." until the user taps manually.

## Fix

### 1. Invalidate stale cache in `render()`
After reading `KEY_DATA`, compare `KEY_DAY` against `os.date("%Y-%m-%d")`. If the day changed, clear the cached data, reset the pages cache and view index, and let the existing no-data branch trigger a fresh fetch.

### 2. Use `StartMenu._live:_reload()` in the fetch callback
Replace `UIManager:setDirty(nil, "ui")` with `StartMenu._live:_reload()` — the same pattern used by other async modules (`useless_facts`, `weather`, etc.) — so the menu card rebuilds automatically when new data arrives.

## Impact
- Minimal change: two small blocks modified, no structural changes
- No breaking changes: behaves identically for the normal case (same day)
- Fixes the real-world scenario of e-readers resuming from standby on a new day