### PR TITLE
Fix bulk Best Guess Hardcover matching

### DIFF
--- a/lib/bookshelf_hardcover.lua
+++ b/lib/bookshelf_hardcover.lua
@@ -1225,26 +1225,70 @@ local function _candidateGenres(b)
     return #out > 0 and out or nil
 end
 
+-- Hardcover's search can return unrelated books when the author is appended to
+-- the title query. Keep the manual and automatic link paths on the same
+-- candidate set: when none of the combined-query results resembles the local
+-- title, retry title-only and merge any new books. The retry is deliberately
+-- conditional so the common path keeps its single API call.
+local function _findBooksWithTitleFallback(modules, title, author, user_id)
+    local books, err = modules.Api:findBooks(title, author, user_id)
+    if not (author and author ~= "" and type(books) == "table") then
+        return books, err
+    end
+
+    local Match = require("lib/bookshelf_hardcover_match")
+    for _, book in ipairs(books) do
+        local title_score = select(1,
+            Match.scoreMatch(title, "x", book.title or "", "x"))
+        if title_score and title_score >= Match.TITLE_THRESHOLD then
+            return books, err
+        end
+    end
+
+    local ok, more = pcall(function()
+        return modules.Api:findBooks(title, "", user_id)
+    end)
+    if not ok or type(more) ~= "table" then return books, err, true end
+
+    local seen = {}
+    for _, book in ipairs(books) do
+        local id = book.book_id or book.id
+        if id then seen[id] = true end
+    end
+    for _, book in ipairs(more) do
+        local id = book.book_id or book.id
+        if id and not seen[id] then
+            seen[id] = true
+            books[#books + 1] = book
+        end
+    end
+    return books, err
+end
+
 -- "Best guess" link: full-text search Hardcover by the book's title + author,
 -- score the hits with the ebook-enricher heuristics, and link the best
 -- confident, canonical match (or nothing). Like linkFromEmbeddedIdentifiers it
 -- only links; the caller enriches afterwards. On success returns a details
--- table { title, author, title_score, author_score } for the report.
+-- table { title, author, title_score, author_score }. On failure the third
+-- return is "no_match" or "error" so bulk scans can report failures honestly.
 function Hardcover.bestGuessLink(book)
-    if not (book and book.filepath) then return false, "Missing local book" end
+    if not (book and book.filepath) then
+        return false, "Missing local book", "error"
+    end
     local title = book.title or _filenameTitle(book.filepath)
     local author = _authorString(book)
-    if not title or title == "" then return false, "No title to search" end
+    if not title or title == "" then
+        return false, "No title to search", "no_match"
+    end
 
     local modules, _settings, user_id, ctx_err = _openPickerContext()
-    if not modules then return false, ctx_err end
-    local ok_search, results = pcall(function()
-        return modules.Api:findBooks(title, author or "", user_id)
-    end)
+    if not modules then return false, ctx_err, "error" end
+    local ok_search, results, _search_err, retry_failed = pcall(
+        _findBooksWithTitleFallback, modules, title, author or "", user_id)
     if not ok_search or type(results) ~= "table" then
-        return false, "Hardcover search failed"
+        return false, "Hardcover search failed", "error"
     end
-    if #results == 0 then return false, "no_match" end
+    if #results == 0 then return false, "no_match", "no_match" end
 
     local cands = {}
     for _, b in ipairs(results) do
@@ -1259,10 +1303,13 @@ function Hardcover.bestGuessLink(book)
     local Match = require("lib/bookshelf_hardcover_match")
     local chosen, t_score, a_score = Match.pickBest(
         { title = title, author = author, series = book.series }, cands)
-    if not chosen then return false, "no_confident_match" end
+    if not chosen and retry_failed then
+        return false, "Hardcover title-only search failed", "error"
+    end
+    if not chosen then return false, "no_confident_match", "no_match" end
 
     local ok, link_err = Hardcover.linkBook(book.filepath, chosen._raw)
-    if not ok then return false, link_err end
+    if not ok then return false, link_err, "error" end
     return true, {
         title        = chosen.title,
         author       = chosen.author,
@@ -1283,39 +1330,7 @@ function Hardcover.showBookPicker(book, opts)
     if embedded then
         books = { embedded }
     else
-        books, err = modules.Api:findBooks(title, author, user_id)
-        -- findBooks appends the author to the query, which can skew Hardcover's
-        -- fuzzy search badly (e.g. "Katabasis R. F. Kuang" returns database
-        -- books). If none of the hits' titles resemble the book's, retry
-        -- title-only and merge the new ones in -- "Katabasis" alone tends to
-        -- surface the real book.
-        if author and author ~= "" and type(books) == "table" then
-            local Match = require("lib/bookshelf_hardcover_match")
-            local matched = false
-            for _, b in ipairs(books) do
-                local ts = select(1, Match.scoreMatch(title, "x", b.title or "", "x"))
-                if ts and ts >= Match.TITLE_THRESHOLD then matched = true; break end
-            end
-            if not matched then
-                local ok2, more = pcall(function()
-                    return modules.Api:findBooks(title, "", user_id)
-                end)
-                if ok2 and type(more) == "table" and #more > 0 then
-                    local seen = {}
-                    for _, b in ipairs(books) do
-                        local id = b.book_id or b.id
-                        if id then seen[id] = true end
-                    end
-                    for _, b in ipairs(more) do
-                        local id = b.book_id or b.id
-                        if id and not seen[id] then
-                            seen[id] = true
-                            books[#books + 1] = b
-                        end
-                    end
-                end
-            end
-        end
+        books, err = _findBooksWithTitleFallback(modules, title, author, user_id)
     end
     if not books then return false, err or "No response from Hardcover" end
 

--- a/lib/bookshelf_settings.lua
+++ b/lib/bookshelf_settings.lua
@@ -1810,10 +1810,13 @@ function Settings:_hardcoverSubItems()
             return
         end
 
-        -- ~2 Hardcover calls per processed book (resolve/search, then fetch
-        -- details), so pace at ~2.5s/book to stay under the ~60/min API limit.
-        local RATE = 2.5
-        local est_min = math.max(1, math.ceil(total * RATE / 60))
+        -- Best guess normally makes two Hardcover calls per linked book
+        -- (search + details); its title-only fallback adds a third. Pace it for
+        -- the worst case so rescued matches stay below the ~60/min API limit.
+        -- Exact matching retains its existing two-call cadence.
+        local EXACT_RATE      = 2.5
+        local BEST_GUESS_RATE = 3.1
+        local est_min = math.max(1, math.ceil(total * BEST_GUESS_RATE / 60))
 
         -- Display name for the report: prefer the book's title, fall back to a
         -- de-extensioned filename.
@@ -1847,7 +1850,7 @@ function Settings:_hardcoverSubItems()
             if touchmenu_instance then UIManager:close(touchmenu_instance) end
             runPacedScan{
                 items = candidates,
-                rate  = RATE,
+                rate  = best_guess and BEST_GUESS_RATE or EXACT_RATE,
                 step = function(fp, st)
                     st.linked_list  = st.linked_list  or {}
                     st.nomatch_list = st.nomatch_list or {}
@@ -1856,7 +1859,7 @@ function Settings:_hardcoverSubItems()
                         -- search Hardcover and score the hits.
                         local meta = (Repo.buildBookMeta and Repo.buildBookMeta(fp))
                                      or { filepath = fp }
-                        local ok_call, linked_ok, details =
+                        local ok_call, linked_ok, details, outcome =
                             pcall(Hardcover.bestGuessLink, meta)
                         if ok_call and linked_ok then
                             st.linked = (st.linked or 0) + 1
@@ -1870,6 +1873,8 @@ function Settings:_hardcoverSubItems()
                                 name = nameFor(fp, meta), matched = d.title,
                                 author = d.author, score = score,
                             }
+                        elseif not ok_call or outcome == "error" then
+                            st.errors = (st.errors or 0) + 1
                         else
                             st.no_match = (st.no_match or 0) + 1
                             st.nomatch_list[#st.nomatch_list + 1] = { name = nameFor(fp, meta) }

--- a/tests/_test_hardcover.lua
+++ b/tests/_test_hardcover.lua
@@ -7,6 +7,7 @@ local settings = {}
 local hc_settings = {
     books = {},
 }
+local find_books
 
 package.loaded["lib/bookshelf_settings_store"] = {
     read = function(key, default)
@@ -69,6 +70,11 @@ package.loaded["docsettings"] = {
 
 package.loaded["hardcover/lib/hardcover_api"] = {
     me = function() return { id = 42 } end,
+    findBooks = function(_self, title, author, user_id)
+        assert(user_id == 42, "expected fetched user id")
+        assert(find_books, "findBooks called without a test scenario")
+        return find_books(title, author)
+    end,
     query = function(_self, query, variables)
         if query:find("books_by_pk", 1, true) and variables.id then
             return {
@@ -116,6 +122,21 @@ package.loaded["hardcover/lib/hardcover_api"] = {
     end,
 }
 
+package.loaded["hardcover/lib/user"] = {
+    getId = function() return 42 end,
+}
+package.loaded["hardcover/lib/ui/dialog_manager"] = {}
+package.loaded["hardcover/lib/book"] = {}
+package.loaded["hardcover/lib/hardcover_settings"] = {
+    new = function()
+        return {
+            readSetting = function(_self, key) return hc_settings[key] end,
+            saveSetting = function(_self, key, value) hc_settings[key] = value end,
+            flush = function() end,
+        }
+    end,
+}
+
 -- In-memory backend for the SQLite-backed Hardcover cache (shared helper).
 -- Installs rapidjson + lua-ljsqlite3 stubs so the real cache code paths run;
 -- must be set up BEFORE the module loads. See tests/_helpers.lua.
@@ -139,6 +160,7 @@ end
 
 local function reset()
     settings = {}
+    find_books = nil
     hc_settings = {
         books = {
             ["/books/a.epub"] = { book_id = 123, edition_id = 456, title = "Linked A" },
@@ -359,6 +381,126 @@ test("refreshRatings preserves a linked book the API response omits", function()
         .. tostring(ratings["777"] and ratings["777"].rating))
     assert(ratings["123"].rating == 4.5, "returned entry not updated")
     assert(ratings["999"].rating == false, "unrated returned entry should be false")
+end)
+
+-- ─── Best-guess candidate search ─────────────────────────────────────────────
+
+test("bestGuessLink retries title-only when title and author return unrelated books", function()
+    reset()
+    local calls = {}
+    find_books = function(title, author)
+        calls[#calls + 1] = { title = title, author = author }
+        if author ~= "" then
+            return {
+                { id = 700, title = "Database Systems", contributions = {
+                    { author = { name = "Thomas Connolly" } },
+                } },
+            }
+        end
+        return {
+            { id = 701, title = "Katabasis", contributions = {
+                { author = { name = "R. F. Kuang" } },
+            } },
+        }
+    end
+
+    local ok, details = Hardcover.bestGuessLink{
+        filepath = "/books/katabasis.epub",
+        title = "Katabasis",
+        authors = { "R. F. Kuang" },
+    }
+
+    assert(ok, tostring(details))
+    assert(#calls == 2, "expected combined + title-only searches, got " .. #calls)
+    assert(calls[1].author == "R. F. Kuang", "first search should include author")
+    assert(calls[2].author == "", "retry should be title-only")
+    assert(details.title == "Katabasis", "linked wrong result: " .. tostring(details.title))
+    assert(Hardcover.getLink("/books/katabasis.epub").book_id == 701,
+        "title-only result was not linked")
+end)
+
+test("bestGuessLink keeps the common path to one search", function()
+    reset()
+    local calls = 0
+    find_books = function(_title, _author)
+        calls = calls + 1
+        return {
+            { id = 701, title = "Katabasis", contributions = {
+                { author = { name = "R. F. Kuang" } },
+            } },
+        }
+    end
+
+    local ok, details = Hardcover.bestGuessLink{
+        filepath = "/books/katabasis.epub",
+        title = "Katabasis",
+        authors = { "R. F. Kuang" },
+    }
+
+    assert(ok, tostring(details))
+    assert(calls == 1, "confident combined search should not retry")
+end)
+
+test("bestGuessLink preserves title-only search for books without authors", function()
+    reset()
+    local calls = 0
+    find_books = function(_title, author)
+        calls = calls + 1
+        assert(author == "", "authorless search should pass an empty author")
+        return {
+            { id = 701, title = "Katabasis", contributions = {
+                { author = { name = "R. F. Kuang" } },
+            } },
+        }
+    end
+
+    local ok, message, outcome = Hardcover.bestGuessLink{
+        filepath = "/books/katabasis.epub",
+        title = "Katabasis",
+    }
+
+    assert(not ok, "authorless book must not bypass the author confidence gate")
+    assert(message == "no_confident_match", "unexpected message: " .. tostring(message))
+    assert(outcome == "no_match", "authorless book should be a no-match, not an error")
+    assert(calls == 1, "authorless book should retain its title-only search")
+end)
+
+test("bestGuessLink labels a failed title-only retry as an error", function()
+    reset()
+    find_books = function(_title, author)
+        if author == "" then error("network down") end
+        return {
+            { id = 700, title = "Database Systems", contributions = {
+                { author = { name = "Thomas Connolly" } },
+            } },
+        }
+    end
+
+    local ok, message, outcome = Hardcover.bestGuessLink{
+        filepath = "/books/katabasis.epub",
+        title = "Katabasis",
+        authors = { "R. F. Kuang" },
+    }
+
+    assert(not ok, "failed retry should not link")
+    assert(message == "Hardcover title-only search failed",
+        "unexpected message: " .. tostring(message))
+    assert(outcome == "error", "failed retry should be classified as an error")
+end)
+
+test("bestGuessLink labels search failures as errors", function()
+    reset()
+    find_books = function() error("network down") end
+
+    local ok, message, outcome = Hardcover.bestGuessLink{
+        filepath = "/books/katabasis.epub",
+        title = "Katabasis",
+        authors = { "R. F. Kuang" },
+    }
+
+    assert(not ok, "search failure should not link")
+    assert(message == "Hardcover search failed", "unexpected message: " .. tostring(message))
+    assert(outcome == "error", "search failure should be classified as an error")
 end)
 
 -- ─── Pass-2 link-time auto-decision ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- share the individual Hardcover picker's title-only fallback with automatic Best Guess linking
- preserve the existing 80/80 title-and-author confidence gate and avoid extra API calls when the combined query already returns a plausible title
- classify actual search/link failures separately from ordinary no-match results in bulk reports
- pace Best Guess for its worst-case three-call fallback path while retaining Exact mode's existing cadence

## Why

Hardcover's search can return unrelated books when the author is appended to the title. The individual picker already detects that case and retries title-only, but `bestGuessLink` scored only the initial combined-query results. Consequently, bulk Best Guess could reject books that the individual lookup found immediately because the correct book never entered the automatic matcher's candidate set.

The candidate lookup now has one shared implementation, so manual and automatic linking cannot drift again.

## Safety

The matcher thresholds are unchanged: both title and author must still score at least 80, and non-canonical adaptations/collections remain rejected. The fallback only broadens the candidate set when none of the initial result titles clears the existing title threshold.

Best Guess now waits 3.1 seconds per processed book in the worst-case path (combined search, title-only retry, details fetch), keeping it below Hardcover's approximately 60 requests/minute limit. Exact mode remains at 2.5 seconds.

## Tests

- regression: unrelated `title + author` results are rescued by title-only search
- common path: a plausible initial title performs only one search
- initial and fallback search failures are classified as errors
- `LUA=/tmp/lua54-pkg/root/usr/bin/lua5.4 sh tests/run.sh` — 50 suites, 0 failed, 1 skipped
- LuaJIT syntax compilation — 151/151 Lua files passed
- `msgfmt --check` — 12/12 translations passed
- `git diff --check`

Fixes #310
