### PR TITLE
feat: add %sysused token for system memory used in MiB

### DIFF
--- a/lib/bookshelf_tokens.lua
+++ b/lib/bookshelf_tokens.lua
@@ -102,6 +102,7 @@ Tokens.CATALOGUE = {
     { category = "Device",   token = "%light_icon",       description = _("Frontlight icon") },
     { category = "Device",   token = "%warmth",           description = _("Warmth value (natural-light only)") },
     { category = "Device",   token = "%mem",              description = _("System memory used (%)") },
+    { category = "Device",   token = "%sysused",           description = _("System memory used (MiB)") },
     { category = "Device",   token = "%ram",              description = _("KOReader RSS (MiB)") },
     { category = "Device",   token = "%disk",             description = _("Storage free (GB)") },
     { category = "Logic",    token = "[if:foo]…[/if]",    description = _("Show … when token foo is set") },
@@ -734,8 +735,9 @@ Tokens.expanders.light_pct = function(_b, s)
     return tostring(s.light_pct) .. "%"
 end
 Tokens.expanders.warmth= function(_b, s) return s and s.warmth and tostring(s.warmth) or "" end
-Tokens.expanders.mem   = function(_b, s) return s and s.mem and (tostring(s.mem) .. "%") or "" end
-Tokens.expanders.ram   = function(_b, s) return s and s.ram_mib and (tostring(s.ram_mib) .. " MiB") or "" end
+Tokens.expanders.mem     = function(_b, s) return s and s.mem and (tostring(s.mem) .. "%") or "" end
+Tokens.expanders.sysused = function(_b, s) return s and s.sysused_mib and (tostring(s.sysused_mib) .. " MiB") or "" end
+Tokens.expanders.ram     = function(_b, s) return s and s.ram_mib and (tostring(s.ram_mib) .. " MiB") or "" end
 Tokens.expanders.disk  = function(_b, s) return s and s.disk_free or "" end
 
 -- %bar and %spacer are intentionally NOT in the expander table. The

--- a/lib/bookshelf_widget.lua
+++ b/lib/bookshelf_widget.lua
@@ -2948,6 +2948,10 @@ local function _readSlowState(now)
         local free, total = util.calcFreeMem()
         if free and total and total > 0 then
             out.mem = math.floor((1 - free / total) * 100 + 0.5)
+            -- Total - free gives used memory in bytes; convert to MiB.
+            -- calcFreeMem already handles MemAvailable fallback (pre-3.14
+            -- kernels), so this works on old Kindle devices too.
+            out.sysused_mib = math.floor((total - free) / 1024 / 1024 + 0.5)
         end
     end
     -- Single read + one match instead of fh:lines() (which allocates a
@@ -3041,9 +3045,10 @@ function BookshelfWidget:_buildDeviceState()
         light    = light,
         light_pct= light_pct,
         warmth   = warmth,
-        mem      = slow.mem,
-        ram_mib  = slow.ram_mib,
-        disk_free= slow.disk_free,
+        mem        = slow.mem,
+        sysused_mib= slow.sysused_mib,
+        ram_mib    = slow.ram_mib,
+        disk_free  = slow.disk_free,
     }
     _device_state_expires_at = now + DEVICE_STATE_TTL
     return _device_state_cache


### PR DESCRIPTION
## Summary

Add a new `%sysused` device token that displays system-wide used memory in MiB, complementing the existing `%mem` (percentage) and `%ram` (KOReader process RSS in MiB).

## Motivation

Currently bookshelf offers:

- `%mem` — system memory used as a percentage (e.g. `33%`)
- `%ram` — KOReader process RSS in MiB (e.g. `128 MiB`)

There is no token for system-wide used memory in MiB. This is useful on memory-constrained devices (e.g. Kindle PaperWhite 3 with 512MB RAM) where users want to see the absolute number rather than just a percentage.

## Implementation

The value is derived from `util.calcFreeMem()` which returns `free` and `total` in bytes. `sysused_mib` is computed as `math.floor((total - free) / 1024 / 1024 + 0.5)`.

`util.calcFreeMem()` already handles the `MemAvailable` fallback for kernels prior to 3.14 (e.g. Kindle PaperWhite 3 running 2.6.x), so no additional compatibility code is needed. This is the same function that `%mem` already uses, so the two tokens are always consistent.

## Changes

- `lib/bookshelf_widget.lua` `_readSlowState`: compute `sysused_mib` alongside `mem`
- `lib/bookshelf_widget.lua` `_buildDeviceState`: pass `sysused_mib` through to token renderers
- `lib/bookshelf_tokens.lua`: register `%sysused` in `CATALOGUE` and `expanders`