### PR TITLE
Opds filename handling

### DIFF
--- a/lib/bookshelf_opds_download.lua
+++ b/lib/bookshelf_opds_download.lua
@@ -40,6 +40,63 @@ D.DESC_STORE_KEY = "opds_descriptions"
 -- impossible rather than merely tested-for.
 local EXT_BY_TYPE = require("lib/bookshelf_opds_feed").TYPE_EXT
 
+-- serverFilename(remote_url, mime_type, username, password) -> filename
+--
+-- The stock OPDS browser's "Use server filenames" path does a HEAD request,
+-- preferring Content-Disposition, then a redirect location, then the URL
+-- basename.  Keep the same order and URL decoding here so a catalog behaves
+-- identically whether it is opened in the stock browser or in Bookshelf.
+function D.serverFilename(remote_url, mime_type, username, password)
+    if type(remote_url) ~= "string" or remote_url == "" then return nil end
+
+    local ok_req, http, ltn12, socket, socketutil, util = pcall(function()
+        return require("socket.http"), require("ltn12"), require("socket"),
+               require("socketutil"), require("util")
+    end)
+    if not ok_req then return nil end
+    local headers
+    local ok = pcall(function()
+        socketutil:set_timeout(socketutil.LARGE_BLOCK_TIMEOUT, socketutil.LARGE_TOTAL_TIMEOUT)
+        local _code, got = socket.skip(1, http.request{
+            url = remote_url,
+            method = "HEAD",
+            headers = { ["Accept-Encoding"] = "identity" },
+            sink = ltn12.sink.table({}),
+            user = username,
+            password = password,
+        })
+        headers = got
+    end)
+    pcall(function() socketutil:reset_timeout() end)
+
+    local filename
+    if ok and type(headers) == "table" then
+        local disposition = headers["content-disposition"]
+        if type(disposition) == "string" then
+            filename = disposition:match('filename="([^"]+)"')
+                or disposition:match("filename=([^;]+)")
+        end
+        if not filename and type(headers.location) == "string" then
+            filename = headers.location:gsub(".*/", "")
+        end
+    end
+    if not filename then
+        filename = remote_url:gsub(".*/", ""):gsub("?.*", "")
+    end
+
+    if mime_type and filename then
+        local suffix = util.getFileNameSuffix(filename)
+        local ok_registry, DocumentRegistry = pcall(require, "document/documentregistry")
+        local usable = suffix and ok_registry
+            and DocumentRegistry:hasProvider("dummy." .. suffix)
+        if not usable then
+            local ext = EXT_BY_TYPE[mime_type]
+            if ext then filename = filename .. "." .. ext end
+        end
+    end
+    return filename ~= "" and util.urlDecode(filename) or nil
+end
+
 -- destinationDir(read_setting) -> dir|nil
 --
 -- read_setting is a function(key) -> value, closure-injected the same way

--- a/lib/bookshelf_opds_source.lua
+++ b/lib/bookshelf_opds_source.lua
@@ -28,7 +28,7 @@ function M.serverKey(url)
 end
 
 -- Validate + map a raw server list (the stock plugin's own shape,
--- { title, url, username?, password? }) into our chip-source records. Shared
+-- { title, url, username?, password?, raw_names? }) into our chip-source records. Shared
 -- by both the live and the file paths so the two can never disagree on which
 -- entries survive or how their keys are derived.
 local function mapServers(list)
@@ -44,6 +44,10 @@ local function mapServers(list)
                 url      = s.url,
                 username = type(s.username) == "string" and s.username or nil,
                 password = type(s.password) == "string" and s.password or nil,
+                -- Stock's "Use server filenames" setting.  Keep this on the
+                -- resolved server record so the download path can make the
+                -- same choice the stock OPDS browser makes.
+                raw_names = s.raw_names == true or nil,
             }
         end
     end

--- a/lib/bookshelf_widget.lua
+++ b/lib/bookshelf_widget.lua
@@ -13088,7 +13088,12 @@ end
 -- uppercased, taken from OpdsDownload.filenameFor rather than a second MIME
 -- table here so the label can never disagree with the filename produced.
 local function opdsAcquisitionLabel(book, acq)
-    if type(acq.title) == "string" and acq.title ~= "" then return acq.title end
+    if type(acq.title) == "string" and acq.title ~= "" then
+        -- Match the stock OPDS browser, which decodes an acquisition link's
+        -- title before showing it. Some servers put the URL-escaped filename
+        -- here, which otherwise leaks %E5%... into the Download button.
+        return require("socket.url").unescape(acq.title)
+    end
     local ok_d, D = pcall(require, "lib/bookshelf_opds_download")
     local name = ok_d and D.filenameFor(book, acq) or nil
     local ext = type(name) == "string" and name:match("%.([^.]+)$") or nil

--- a/lib/bookshelf_widget.lua
+++ b/lib/bookshelf_widget.lua
@@ -13568,7 +13568,25 @@ function BookshelfWidget:_opdsStartDownload(book, acq, dialog)
     if dest then
         name = dest:match("([^/]+)$")
     else
-        name = util.getSafeFilename(D.filenameFor(book, acq), dir)
+        local filename = D.filenameFor(book, acq)
+        local key = type(book.filepath) == "string"
+            and book.filepath:match("^OPDS://([^/]+)/") or nil
+        local OpdsSource = require("lib/bookshelf_opds_source")
+        local OpdsFeed = require("lib/bookshelf_opds_feed")
+        local server = key and OpdsSource.getServer(key) or nil
+        if server and server.raw_names then
+            -- This is deliberately the stock browser's pre-download HEAD
+            -- lookup: server names decide the *target path*, so it has to run
+            -- before the overwrite prompt and before the GET opens a file.
+            local same_origin = OpdsFeed.sameOrigin(server.url, acq.href)
+            local server_name = D.serverFilename(acq.href, acq.type,
+                same_origin and server.username or nil,
+                same_origin and server.password or nil)
+            if type(server_name) == "string" and server_name ~= "" then
+                filename = server_name
+            end
+        end
+        name = util.getSafeFilename(filename, dir)
         dest = (dir ~= "/" and dir or "") .. "/" .. name
         -- Don't offer to overwrite a file that belongs to a DIFFERENT catalog
         -- record: filenameFor is author + title + format and getSafeFilename

--- a/tests/_test_opds_download.lua
+++ b/tests/_test_opds_download.lua
@@ -71,6 +71,7 @@ package.loaded["socket/http"] = {
         return 1, resp.code, resp.headers or {}, resp.status
     end,
 }
+package.loaded["socket.http"] = package.loaded["socket/http"]
 package.loaded["ltn12"] = {
     sink = {
         -- Matches real ltn12.sink.file: a nil chunk closes the handle.
@@ -223,29 +224,6 @@ end)
 
 -- ================== filenameFor ==================
 
-t.test("serverFilename: matches stock precedence and URL-decodes Content-Disposition", function()
-    reset()
-    local u = "https://example.com/download/opaque"
-    http_responses[u] = {
-        code = 200,
-        headers = { ["content-disposition"] = 'attachment; filename="%E5%8D%81%E4%BA%8C%E5%9B%BD%E8%AE%B0.epub"' },
-    }
-    eq(D.serverFilename(u, "application/epub+zip", "u", "p"), "十二国记.epub")
-    eq(requests[#requests].method, "HEAD", "server filename lookup must use HEAD")
-end)
-
-t.test("serverFilename: falls back to redirect then URL, adding a supported extension", function()
-    reset()
-    local redirected = "https://example.com/download/opaque"
-    http_responses[redirected] = { code = 302, headers = { location = "https://cdn/x/%E4%B9%A6" } }
-    eq(D.serverFilename(redirected, "application/epub+zip"), "书.epub")
-
-    reset()
-    local plain = "https://example.com/download/%E4%B9%A6?token=1"
-    http_responses[plain] = { code = 404 }
-    eq(D.serverFilename(plain, "application/epub+zip"), "书.epub")
-end)
-
 t.test("filenameFor: maps each known acquisition type to its extension", function()
     local rec = { title = "Some Book" }
     local cases = {
@@ -380,6 +358,29 @@ local function reset()
     for i = #removed_paths, 1, -1 do removed_paths[i] = nil end
     for i = #timeout_calls, 1, -1 do timeout_calls[i] = nil end
 end
+
+t.test("serverFilename: matches stock precedence and URL-decodes Content-Disposition", function()
+    reset()
+    local u = "https://example.com/download/opaque"
+    http_responses[u] = {
+        code = 200,
+        headers = { ["content-disposition"] = 'attachment; filename="%E5%8D%81%E4%BA%8C%E5%9B%BD%E8%AE%B0.epub"' },
+    }
+    eq(D.serverFilename(u, nil, "u", "p"), "十二国记.epub")
+    eq(requests[#requests].method, "HEAD", "server filename lookup must use HEAD")
+end)
+
+t.test("serverFilename: falls back to redirect then URL, adding a supported extension", function()
+    reset()
+    local redirected = "https://example.com/download/opaque"
+    http_responses[redirected] = { code = 302, headers = { location = "https://cdn/x/%E4%B9%A6" } }
+    eq(D.serverFilename(redirected, "application/epub+zip"), "书.epub")
+
+    reset()
+    local plain = "https://example.com/download/%E4%B9%A6?token=1"
+    http_responses[plain] = { code = 404 }
+    eq(D.serverFilename(plain, "application/epub+zip"), "书.epub")
+end)
 
 t.test("download: a 200 response writes the body atomically (tmp then rename)", function()
     reset()

--- a/tests/_test_opds_download.lua
+++ b/tests/_test_opds_download.lua
@@ -62,7 +62,7 @@ package.loaded["socket/http"] = {
     request = function(reqt)
         requests[#requests + 1] = { url = reqt.url, user = reqt.user,
                                     password = reqt.password,
-                                    headers = reqt.headers }
+                                    headers = reqt.headers, method = reqt.method }
         local resp = http_responses[reqt.url] or { code = 200, body = "" }
         if reqt.sink then
             if resp.body and resp.body ~= "" then reqt.sink(resp.body) end
@@ -80,6 +80,12 @@ package.loaded["ltn12"] = {
                 return handle:write(chunk)
             end
         end,
+        table = function(out)
+            return function(chunk)
+                if chunk then out[#out + 1] = chunk end
+                return 1
+            end
+        end,
     },
 }
 package.loaded["socket"] = {
@@ -94,6 +100,16 @@ package.loaded["socketutil"] = {
     FILE_BLOCK_TIMEOUT  = 15, FILE_TOTAL_TIMEOUT  = 60,
     set_timeout = function(_self, b, t) timeout_calls[#timeout_calls + 1] = { b, t } end,
     reset_timeout = function() end,
+}
+package.loaded["util"] = {
+    getFileNameSuffix = function(filename)
+        return type(filename) == "string" and filename:match("%.([^.]+)$") or nil
+    end,
+    urlDecode = function(value)
+        return value and value:gsub("%%(%x%x)", function(hex)
+            return string.char(tonumber(hex, 16))
+        end)
+    end,
 }
 package.loaded["logger"] = { dbg = function() end, info = function() end,
                              warn = function() end, err = function() end }
@@ -206,6 +222,29 @@ t.test("destinationDir: the effective dir equal to home_dir itself counts as ins
 end)
 
 -- ================== filenameFor ==================
+
+t.test("serverFilename: matches stock precedence and URL-decodes Content-Disposition", function()
+    reset()
+    local u = "https://example.com/download/opaque"
+    http_responses[u] = {
+        code = 200,
+        headers = { ["content-disposition"] = 'attachment; filename="%E5%8D%81%E4%BA%8C%E5%9B%BD%E8%AE%B0.epub"' },
+    }
+    eq(D.serverFilename(u, "application/epub+zip", "u", "p"), "十二国记.epub")
+    eq(requests[#requests].method, "HEAD", "server filename lookup must use HEAD")
+end)
+
+t.test("serverFilename: falls back to redirect then URL, adding a supported extension", function()
+    reset()
+    local redirected = "https://example.com/download/opaque"
+    http_responses[redirected] = { code = 302, headers = { location = "https://cdn/x/%E4%B9%A6" } }
+    eq(D.serverFilename(redirected, "application/epub+zip"), "书.epub")
+
+    reset()
+    local plain = "https://example.com/download/%E4%B9%A6?token=1"
+    http_responses[plain] = { code = 404 }
+    eq(D.serverFilename(plain, "application/epub+zip"), "书.epub")
+end)
 
 t.test("filenameFor: maps each known acquisition type to its extension", function()
     local rec = { title = "Some Book" }

--- a/tests/_test_opds_source.lua
+++ b/tests/_test_opds_source.lua
@@ -26,7 +26,7 @@ ok(Src.isAvailable() == false, "missing file -> unavailable")
 local f = io.open(path, "w")
 f:write([[return {
     ["servers"] = {
-        { ["title"] = "Test Cat", ["url"] = "http://localhost:8080/", ["username"] = "u", ["password"] = "p" },
+        { ["title"] = "Test Cat", ["url"] = "http://localhost:8080/", ["username"] = "u", ["password"] = "p", ["raw_names"] = true },
         { ["title"] = "No URL entry" },
         { ["title"] = 42, ["url"] = "http://x/" },
         "not even a table",
@@ -37,6 +37,7 @@ local list = Src.servers()
 ok(#list == 1, "only the valid entry survives, got " .. #list)
 ok(list[1].title == "Test Cat" and list[1].url == "http://localhost:8080/", "fields carried")
 ok(list[1].username == "u" and list[1].password == "p", "credentials carried")
+ok(list[1].raw_names == true, "Use server filenames carried")
 ok(type(list[1].key) == "string" and #list[1].key == 8, "key is 8 hex chars")
 ok(Src.getServer(list[1].key) ~= nil, "getServer round-trips")
 ok(Src.getServer("ffffffff") == nil, "unknown key -> nil")


### PR DESCRIPTION
## Summary

Bookshelf already shares OPDS catalog settings with KOReader, including the **Use server filenames** option, but previously ignored that option when downloading books.

This change passes the setting through to the download flow. When enabled, Bookshelf follows the same filename lookup order as KOReader’s OPDS browser: `Content-Disposition`, redirect location, then the download URL. If no usable server filename is found, it keeps the existing title-based filename.

It also URL-decodes acquisition titles shown in the download menu, fixing labels such as percent-encoded Chinese filenames.

## Testing

Added tests for server filename handling and `raw_names` propagation.