### PR TITLE
Add US English localization overrides

### DIFF
--- a/lib/bookshelf_i18n.lua
+++ b/lib/bookshelf_i18n.lua
@@ -77,25 +77,28 @@ local ok_ko, ko_gettext = pcall(require, "gettext")
 if not ok_ko then ko_gettext = function(t) return t end end
 local translations
 
-local lang = detectLang()
-if lang ~= "en" and lang ~= "en_US" then
-    local function try(name)
-        local path = _base .. "locale/" .. name .. ".po"
-        local t = parsePO(path)
-        if t and next(t) then
-            local n = 0; for _k in pairs(t) do n = n + 1 end
-            logger.dbg("bookshelf i18n: loaded " .. path .. " -- " .. n .. " strings")
-            return t
-        end
+local function try(name)
+    local path = _base .. "locale/" .. name .. ".po"
+    local t = parsePO(path)
+    if t and next(t) then
+        local n = 0; for _k in pairs(t) do n = n + 1 end
+        logger.dbg("bookshelf i18n: loaded " .. path .. " -- " .. n .. " strings")
+        return t
     end
+end
+
+local lang = detectLang()
+if lang == "en" or lang == "en_US" then
+    translations = try("en_US")
+else
     translations = try(lang) or (function()
         local prefix = lang:match("^([a-zA-Z]+)")
         if prefix and prefix ~= lang then return try(prefix) end
     end)()
+end
 
-    if translations then
-        logger.dbg("bookshelf i18n: installed for language: " .. lang)
-    end
+if translations then
+    logger.dbg("bookshelf i18n: installed for language: " .. lang)
 end
 
 --- Translation function: checks Bookshelf .po first, then KOReader gettext.

--- a/locale/en_US.po
+++ b/locale/en_US.po
@@ -1,0 +1,48 @@
+# Bookshelf — KOReader Plugin
+# English (United States) overrides
+# Only strings whose source spelling differs from American English
+msgid ""
+msgstr ""
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Favourite"
+msgstr "Favorite"
+
+msgid "Favourites"
+msgstr "Favorites"
+
+msgid "★ Favourites"
+msgstr "★ Favorites"
+
+msgid "Favourite icon"
+msgstr "Favorite icon"
+
+msgid "Favourite heart color"
+msgstr "Favorite heart color"
+
+msgid "Favourite star color"
+msgstr "Favorite star color"
+
+msgid "Favourite heart color (% black)"
+msgstr "Favorite heart color (% black)"
+
+msgid "Favourite star color (% black)"
+msgstr "Favorite star color (% black)"
+
+msgid "Favourite icon, empty when not a favourite"
+msgstr "Favorite icon, empty when not a favorite"
+
+msgid "Centre"
+msgstr "Center"
+
+msgid "Analogue clock"
+msgstr "Analog clock"
+
+msgid "How much memory to use for ready-scaled book covers. A bigger cache keeps more covers warm -- smoother paging and preloading -- at the cost of RAM. Default 24 MB. Lower it if memory is tight; raise it on a device with plenty of RAM. (How many covers that holds depends on their size: roughly 200-400 small grayscale covers, fewer large or colour ones.)"
+msgstr "How much memory to use for ready-scaled book covers. A bigger cache keeps more covers warm -- smoother paging and preloading -- at the cost of RAM. Default 24 MB. Lower it if memory is tight; raise it on a device with plenty of RAM. (How many covers that holds depends on their size: roughly 200-400 small grayscale covers, fewer large or color ones.)"
+
+msgid "Clears your custom chip layout (which chips are shown, their order, their labels and icons, their sources and filters and sorts) and restores the fresh-install chip set: Home / Recent / Series / Favourites enabled, the rest available to toggle on. Also returns the active chip to Home and the page indicator to 1. Other settings (hero text, fonts, colors) are unaffected."
+msgstr "Clears your custom chip layout (which chips are shown, their order, their labels and icons, their sources and filters and sorts) and restores the fresh-install chip set: Home / Recent / Series / Favorites enabled, the rest available to toggle on. Also returns the active chip to Home and the page indicator to 1. Other settings (hero text, fonts, colors) are unaffected."


### PR DESCRIPTION
Adds a small `en_US` localization catalog so users with US English selected see American spellings without requiring changes throughout the plugin's source strings.

The existing `locale/en_GB.po` describes itself as containing "Only strings that differ from American English," so I realize the intended direction appears to be American English as the canonical source language, with British English handled through `en_GB.po`.

Rather than changing the remaining British spellings across the source, I thought this was a simpler and more flexible way to get the same user-facing result with a very small change:

- Allow `en` / `en_US` to load `locale/en_US.po`
- Add US-English overrides for the British spellings currently exposed in the UI, including:
  - Favourite -> Favorite
  - Favourites -> Favorites
  - Centre -> Center
  - Analogue clock -> Analog clock
  - colour -> color where it appears in translatable UI text
- Leave the existing source strings and all other locales unchanged

This keeps the change isolated to the localization layer and also makes it easy to add or adjust US-specific wording later without touching application code.

Tested locally with Bookshelf v4.4.1 on KOReader.